### PR TITLE
add Dell Latitude E6410 to test_results

### DIFF
--- a/test_results/latitude_e6410/probe_2026-04-09_16-25-04.txt
+++ b/test_results/latitude_e6410/probe_2026-04-09_16-25-04.txt
@@ -1,0 +1,115 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p4 releng/15.0-n281010-8ef0ed690df2 GENERIC
+Hardware: Latitude E6410
+------------------------------------
+
+- Graphics
+  Device 1 Status: WORKS
+    vgapci0@pci0:1:0:0:	class=0x030000 rev=0xa2 hdr=0x00 vendor=0x10de device=0x0a6c subvendor=0x1028 subdevice=0x040a
+        vendor     = 'NVIDIA Corporation'
+        device     = 'GT218M [NVS 3100M]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: DETECTED
+    em0@pci0:0:25:0:	class=0x020000 rev=0x05 hdr=0x00 vendor=0x8086 device=0x10ea subvendor=0x1028 subdevice=0x040a
+        vendor     = 'Intel Corporation'
+        device     = '82577LM Gigabit Network Connection'
+        class      = network
+  Device 2 Status: WORKS
+    iwn0@pci0:3:0:0:	class=0x028000 rev=0x35 hdr=0x00 vendor=0x8086 device=0x422c subvendor=0x8086 subdevice=0x1321
+        vendor     = 'Intel Corporation'
+        device     = 'Centrino Advanced-N 6200'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac1@pci0:0:27:0:	class=0x040300 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b56 subvendor=0x1028 subdevice=0x040a
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset High Definition Audio'
+        class      = multimedia
+        subclass   = HDA
+    hdac0@pci0:1:0:1:	class=0x040300 rev=0xa1 hdr=0x00 vendor=0x10de device=0x0be3 subvendor=0x1028 subdevice=0x040a
+        vendor     = 'NVIDIA Corporation'
+        device     = 'High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: WORKS
+    ahci0@pci0:0:31:2:	class=0x010400 rev=0x05 hdr=0x00 vendor=0x8086 device=0x282a subvendor=0x1028 subdevice=0x040a
+        vendor     = 'Intel Corporation'
+        device     = '82801 Mobile SATA Controller [RAID mode]'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    ehci0@pci0:0:26:0:	class=0x0c0320 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b3c subvendor=0x1028 subdevice=0x040a
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset USB2 Enhanced Host Controller'
+        class      = serial bus
+        subclass   = USB
+    ehci1@pci0:0:29:0:	class=0x0c0320 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b34 subvendor=0x1028 subdevice=0x040a
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset USB2 Enhanced Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+ichsmb.ko
+linux.ko
+linux_common.ko
+mac_ntpd.ko
+mqueuefs.ko
+nvidia.ko
+smbus.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            4
+Thread(s) per core:      2
+Core(s) per socket:      2
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   37
+Model name:              Intel(R) Core(TM) i5 CPU       M 520  @ 2.40GHz
+Stepping:                2
+L1d cache:               32K
+L1i cache:               32K
+L3 cache:                3M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 popcnt aes syscall nx rdtscp lm lahf_lm
+
+====================================


### PR DESCRIPTION
# Summary

tested as an xfce based youtube viewer and all around freebsd play system. it doesn't seem like sleep/hibernation work well but also the lid doesn't want to stay closed so maybe that's just the arthritic reality of a laptop being a teenager. youtube in chromium works fine.

# System information

Laptop make/model: Dell Latitude E6410
`uname -a` output:
```
FreeBSD fbsd_e6410 15.0-RELEASE-p5 FreeBSD 15.0-RELEASE-p5 releng/15.0-n281018-0730d5233286 GENERIC amd64
```

# Tests Completed

## Installation

- [x] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/25

## Wireless

- [x] The laptop has Wi-Fi 5 support (802.11ac)
    https://github.com/FreeBSDFoundation/proj-laptop/issues/33

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/34

- [x] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/4

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [x] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/3

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/15

- [x] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/11
    https://github.com/FreeBSDFoundation/proj-laptop/issues/13

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/14

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    https://github.com/FreeBSDFoundation/proj-laptop/issues/6

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/7

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/29

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/18

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/19

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/27

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/9

- [ ] I can run Windows VMs on the laptop.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/21

# Additional Info

I am running the old nvidia kmod which does appear to affect stability