### PR TITLE
Add Dell XPS to test results

### DIFF
--- a/test_results/xps_9315/probe_2026-04-10_23-38-16.txt
+++ b/test_results/xps_9315/probe_2026-04-10_23-38-16.txt
@@ -1,0 +1,130 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p5 releng/15.0-n281018-0730d5233286 GENERIC
+Hardware: XPS 9315
+------------------------------------
+
+- Graphics
+  Device 1 Status: WORKS
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x0c hdr=0x00 vendor=0x8086 device=0x46aa subvendor=0x1028 subdevice=0x0b14
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-UP4 GT2 [Iris Xe Graphics]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51f0 subvendor=0x8086 subdevice=0x4090
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-P PCH CNVi WiFi'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    none1@pci0:0:5:0:	class=0x048000 rev=0x06 hdr=0x00 vendor=0x8086 device=0x465d subvendor=0x1028 subdevice=0x0b14
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake Imaging Signal Processor'
+        class      = multimedia
+    hdac0@pci0:0:31:3:	class=0x040100 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51cc subvendor=0x1028 subdevice=0x0b14
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake Smart Sound Technology Audio Controller'
+        class      = multimedia
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:1:0:0:	class=0x010802 rev=0x01 hdr=0x00 vendor=0x1344 device=0x5414 subvendor=0x1344 subdevice=0x1400
+        vendor     = 'Micron Technology Inc'
+        device     = '3460 NVMe SSD'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:13:0:	class=0x0c0330 rev=0x06 hdr=0x00 vendor=0x8086 device=0x461e subvendor=0x1028 subdevice=0x0b14
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-P Thunderbolt 4 USB Controller'
+        class      = serial bus
+        subclass   = USB
+    none3@pci0:0:13:2:	class=0x0c0340 rev=0x06 hdr=0x00 vendor=0x8086 device=0x463e subvendor=0x1028 subdevice=0x0b14
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-P Thunderbolt 4 NHI'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51ed subvendor=0x1028 subdevice=0x0b14
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake PCH USB 3.2 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+dmabuf.ko
+drm.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+lindebugfs.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+smbus.ko
+ttm.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            12
+Thread(s) per core:      2
+Core(s) per socket:      6
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   154
+Model name:              12th Gen Intel(R) Core(TM) i7-1250U
+Stepping:                4
+L1d cache:               48K
+L1i cache:               32K
+L2 cache:                1280K
+L3 cache:                12M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust bmi1 avx2 fp_dp smep bmi2 erms invpcid fpcsds rdseed adx smap clflushopt clwb intel_pt umip pku ospke syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary

Dell XPS 9315 Laptop

# System information

Laptop make/model:
`uname -a` output: 
`FreeBSD setmefree 15.0-RELEASE-p5 FreeBSD 15.0-RELEASE-p5 releng/15.0-n281018-0730d5233286 GENERIC amd64`

# Tests Completed

## Installation

- [-] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/25

## Wireless

- [N] The laptop has Wi-Fi 5 support (802.11ac)
    https://github.com/FreeBSDFoundation/proj-laptop/issues/33

- [N] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/34

- [x] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/4

- [-] I can connect my laptop to the internet by tethering with my mobile phone.

- [N] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/3

## Audio/Video

- [-] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/15

- [x] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/11
    https://github.com/FreeBSDFoundation/proj-laptop/issues/13

- [N ] I can share my screen on all popular browsers and other applications that request the webcam.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/14

- [-] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [N] The laptop lasts through an 8-hour workday on a single charge
    https://github.com/FreeBSDFoundation/proj-laptop/issues/6

- [N] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/7

- [N] The laptop can enter and resume from hibernation mode with no change to its operating state.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/29

## User Experience

- [x] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [x] I can use multi-finger touchpad gestures in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/18

- [N] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/19
    * Brightness does not work correctly

- [-] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/27

## Virtualization

- [-] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/9

- [-] I can run Windows VMs on the laptop.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/21

# Additional Info

`sysctl hw.acpi.supported_sleep_state` returns `hw.acpi.supported_sleep_state: S4 S5`

`acpiconf -s 3` returns `acpiconf: request sleep type (3) failed: Operation not supported`
