### PR TITLE
HW scan for Lenovo yoga pro 7 14asp9-83hn

### DIFF
--- a/test_results/lenovo_yoga_pro-7-14asp9-83hn/lenovo-yoga-pro7-14asp9-83hn.txt
+++ b/test_results/lenovo_yoga_pro-7-14asp9-83hn/lenovo-yoga-pro7-14asp9-83hn.txt
@@ -1,0 +1,113 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE releng/15.0-n280995-7aedc8de6446 GENERIC
+Hardware: 83HN
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci0@pci0:98:0:0:	class=0x038000 rev=0xc4 hdr=0x00 vendor=0x1002 device=0x150e subvendor=0x17aa subdevice=0x3815
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Strix [Radeon 880M / 890M]'
+        class      = display
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: FAILED
+    none3@pci0:97:0:0:	class=0x028000 rev=0x00 hdr=0x00 vendor=0x14c3 device=0x0616 subvendor=0x17aa subdevice=0xe0c6
+        vendor     = 'MEDIATEK Corp.'
+        device     = 'MT7922 802.11ax PCI Express Wireless Network Adapter'
+        class      = network
+
+  Category Total Score: 0/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:98:0:1:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1002 device=0x1640 subvendor=0x17aa subdevice=0x3846
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Radeon High Definition Audio Controller [Rembrandt/Strix]'
+        class      = multimedia
+        subclass   = HDA
+    hdac1@pci0:98:0:6:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15e3 subvendor=0x17aa subdevice=0x38a7
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Family 17h/19h/1ah HD Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:96:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x1c5c device=0x1f69 subvendor=0x1c5c subdevice=0x1f69
+        vendor     = 'SK hynix'
+        device     = 'PVC10 NVMe Solid State Drive (DRAM-less)'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:98:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x151e subvendor=0x1022 subdevice=0x151e
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:100:0:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x151f subvendor=0x1022 subdevice=0x151f
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    xhci2@pci0:100:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x151a subvendor=0x1022 subdevice=0x151a
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    xhci3@pci0:100:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x151b subvendor=0x1022 subdevice=0x151b
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    none8@pci0:100:0:5:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x1022 device=0x151c subvendor=0x1022 subdevice=0x151c
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'USB4 Router 0'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            20
+Thread(s) per core:      2
+Core(s) per socket:      10
+Socket(s):               1
+Vendor:                  AuthenticAMD
+CPU family:              26
+Model:                   36
+Model name:              AMD Ryzen AI 9 365 w/ Radeon 880M              
+Stepping:                0
+L1d cache:               48K
+L1i cache:               32K
+L2 cache:                1024K
+L3 cache:                8M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh mmx fxsr sse sse2 htt sse3 pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 popcnt aes xsave osxsave avx f16c rdrnd syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm lahf_lm cmp_legacy svm extapic cr8_legacy lzcnt sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb pcx_l2i
+
+====================================


### PR DESCRIPTION
# Summary

Hi there, I have performed HW scan using the mfbsd image with built  `python`  and `hw-probe` packages. So, I am not sure if such a report is useful at the moment because I see that there are multiple test cases to be done.

# System information

Laptop make/model:
`uname -a` output: FreeBSD mfsbsd 15.0-RELEASE FreeBSD 15.0-RELEASE releng/15.0-n280995-7aedc8de6446 GENERIC amd64

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/25

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    https://github.com/FreeBSDFoundation/proj-laptop/issues/33

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/34

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/4

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/3

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/15

- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/11
    https://github.com/FreeBSDFoundation/proj-laptop/issues/13

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/14

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    https://github.com/FreeBSDFoundation/proj-laptop/issues/6

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/7

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/29

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/18

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/19

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/27

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/9

- [ ] I can run Windows VMs on the laptop.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/21

# Additional Info

Not sure if this will be helpful as a reference point (for drivers & fw blobs) but I am using  using Debian Linux 13,  running on `Linux 6.19.11+deb14-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.19.11-1 (2026-04-05) x86_64 GNU/Linux` with latest firmware blobs and it works fine.

I was able to run live GhostBSD (it is built on the top of FreeBSD if I am not mistaken) with working graphical environment. WIFI and Bluetooth wasn't working but it might be the case that I needed to load some driver.

It will be great if FreeBSD can have wider HW support so I can use it on my laptop :). I am using it on a router and VM at the moment and it is perfect OS!
