### PR TITLE
Add test results: Samsung Galaxy Book 2 NP550XED

### DIFF
--- a/test_results/550xed/probe_2026-04-13_18-34-05.txt
+++ b/test_results/550xed/probe_2026-04-13_18-34-05.txt
@@ -1,0 +1,102 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 14.2-RELEASE releng/14.2-n269506-c8918d6c7412 GENERIC
+Hardware: 550XED
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x0c hdr=0x00 vendor=0x8086 device=0x46b3 subvendor=0x144d subdevice=0xc878
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-UP3 GT1 [UHD Graphics]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    none3@pci0:0:20:3:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51f0 subvendor=0x8086 subdevice=0x0034
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-P PCH CNVi WiFi'
+        class      = network
+  Device 2 Status: FAILED
+    re0@pci0:2:0:0:	class=0x020000 rev=0x15 hdr=0x00 vendor=0x10ec device=0x8168 subvendor=0x144d subdevice=0xc878
+        vendor     = 'Realtek Semiconductor Co., Ltd.'
+        device     = 'RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller'
+        class      = network
+
+  Category Total Score: 1/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:31:3:	class=0x040100 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51c8 subvendor=0x144d subdevice=0xc878
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake PCH-P High Definition Audio Controller'
+        class      = multimedia
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    ahci0@pci0:0:23:0:	class=0x010601 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51d3 subvendor=0x144d subdevice=0xc878
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake-P SATA AHCI Controller'
+        class      = mass storage
+  Device 2 Status: WORKS
+    nvme0@pci0:1:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa809 subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller 980 (DRAM-less)'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:20:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51ed subvendor=0x144d subdevice=0xc878
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake PCH USB 3.2 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            8
+Thread(s) per core:      1
+Core(s) per socket:      8
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   154
+Model name:              12th Gen Intel(R) Core(TM) i3-1215U
+Stepping:                4
+L1d cache:               32K
+L1i cache:               64K
+L2 cache:                2048K
+L3 cache:                10M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust bmi1 avx2 fp_dp smep bmi2 erms invpcid fpcsds rdseed adx smap clflushopt clwb intel_pt umip pku ospke syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary

Tested FreeBSD 14.2 hardware compatibility on Samsung Galaxy Book 2 NP550XED using mfsBSD live environment.

# System information

Laptop make/model: Samsung Galaxy Book 2 NP550XED (Intel Core i3-1215U, 16GB RAM, Intel UHD Graphics)
`uname -a` output: FreeBSD mfsbsd 14.2-RELEASE FreeBSD 14.2-RELEASE releng/14.2-n269506-c8918d6c7412 GENERIC amd64

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/25

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    https://github.com/FreeBSDFoundation/proj-laptop/issues/33

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/34

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/4

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/3

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/15

- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/11
    https://github.com/FreeBSDFoundation/proj-laptop/issues/13

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/14

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    https://github.com/FreeBSDFoundation/proj-laptop/issues/6

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/7

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/29

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/18

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/19

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/27

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/9

- [ ] I can run Windows VMs on the laptop.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/21

# Additional Info

Tested using mfsBSD 14.2 live environment (no installation). Wi-Fi was not detected by FreeBSD. Ethernet (re0) worked after dhclient. hw-probe ran successfully.