### PR TITLE
Test results on thinkpad x1 carbon gen11

### DIFF
--- a/test_results/Lenovo_ThinkPad_X1_Carbon_gen11/probe_2026-04-27_09-15-15.txt
+++ b/test_results/Lenovo_ThinkPad_X1_Carbon_gen11/probe_2026-04-27_09-15-15.txt
@@ -1,0 +1,131 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p6 releng/15.0-n281024-6b6bc9afa0b0 GENERIC
+Hardware: 21HMCTO1WW
+------------------------------------
+
+- Graphics
+  Device 1 Status: WORKS
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x04 hdr=0x00 vendor=0x8086 device=0xa7a0 subvendor=0x17aa subdevice=0x2315
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P [Iris Xe Graphics]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51f1 subvendor=0x8086 subdevice=0x0090
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake PCH CNVi WiFi'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:31:3:	class=0x040380 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51ca subvendor=0x17aa subdevice=0x2315
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P/U/H cAVS'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:4:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa80a subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller PM9A1/PM9A3/980PRO'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:13:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa71e subvendor=0x17aa subdevice=0x2315
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P Thunderbolt 4 USB Controller'
+        class      = serial bus
+        subclass   = USB
+    none4@pci0:0:13:2:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa73e subvendor=0x17aa subdevice=0x2315
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P Thunderbolt 4 NHI'
+        class      = serial bus
+        subclass   = USB
+    none5@pci0:0:13:3:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa76d subvendor=0x17aa subdevice=0x2315
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P Thunderbolt 4 NHI'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51ed subvendor=0x17aa subdevice=0x2315
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake PCH USB 3.2 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+dmabuf.ko
+drm.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+lindebugfs.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+smbus.ko
+ttm.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            20
+Thread(s) per core:      1
+Core(s) per socket:      20
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   186
+Model name:              13th Gen Intel(R) Core(TM) i7-1370P
+Stepping:                2
+L1d cache:               32K
+L1i cache:               64K
+L2 cache:                2048K
+L3 cache:                24M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust bmi1 avx2 fp_dp smep bmi2 erms invpcid fpcsds rdseed adx smap clflushopt clwb intel_pt umip pku ospke syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary

Installed a fresh FreeBSD 15.0 on the laptop and ran the run_hwprobe.sh script

# System information

Laptop make/model:
`uname -a` output: `FreeBSD caw 15.0-RELEASE-p6 FreeBSD 15.0-RELEASE-p6 releng/15.0-n281024-6b6bc9afa0b0 GENERIC amd64`

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/25

## Wireless

- [x] The laptop has Wi-Fi 5 support (802.11ac)
    https://github.com/FreeBSDFoundation/proj-laptop/issues/33

- [x] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/34

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/4

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/3

## Audio/Video

- [x] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/15

- [x] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/11
    https://github.com/FreeBSDFoundation/proj-laptop/issues/13

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/14

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    https://github.com/FreeBSDFoundation/proj-laptop/issues/6

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/7

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/29

## User Experience

- [x] I can change ~the keyboard backlight and~ display backlight to view at a comfortable brightness.

- [x] I can use multi-finger touchpad gestures in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/18

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/19

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/27

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/9

- [ ] I can run Windows VMs on the laptop.
    https://github.com/FreeBSDFoundation/proj-laptop/issues/21

# Additional Info

Moin! Some notes from going through this list:

- The TUI installer and base system installs fine and easily. It was unfortunately a bit of research to get to the point where KDE was running and I was able to more or less treat this laptop like a typical workstation.
- Wifi setup was handled during the install and presented a couple of head scratchers to someone like me more accustomed to NetworkManager. But the driver for this laptop was found by the installer and there was no real technical hurdle to vault.
- The option for entering sleep mode in the kde menus are disabled, but *hibernate is enabled*. When I tried to hibernate though, it didn't appear to work. Opening the laptop lid did start the computer up, but it was as if it was a fresh boot.
- Bluetooth doesn't appear to be enabled (perhaps I need to install something still) so I wasn't able to test tethering with my phone.
- I didn't try to use this for a full 8-hours at this point. The laptop runs warmer than usual (comparing to Arch and CachyOS). KDE battery widget indicates about 2.5 hours remaining after about 30 minutes of use. But I wouldn't say that's much worse than what this machine gets typically.
- The "media keys" on the keyboard mostly don't work. Volume keys work, but the rest do nothing. Inspecting the layout in KDE settings shows that the layout is set to a generic option. There was no change when I tested with several of the Lenovo options. Going into the shortcuts editor and attempting to assign whatever key mapped to the brightness keys showed that no key event was emitted when pressing the keys.
- I did not run any VM tests at this time.
- I was able to run vkcube just fine. vulkaninfo returned all the expected information. 
- Youtube played several videos in fullscreen without any screen tearing.
- Blender ran excellently, *but* closing the window froze the desktop. Switching to tty1 and then back seemed to be enough to unclog the works thankfully.