### PR TITLE
Lenovo ThinkPad E-15 Gen. 2

### DIFF
--- a/test_results/Lenovo_ThinkPad_E15_Gen2/comments.md
+++ b/test_results/Lenovo_ThinkPad_E15_Gen2/comments.md
@@ -1,0 +1,42 @@
+laptop info: Lenovo ThinkPad E-15 Gen 2, Intel Core i5 1135G7
+
+known issues and bugs:
+1. after resume from S3:
+    * applications will take a long time to open on sway and internet will be
+    gone with ping showing 100% packet loss -- `service netif restart` fixes
+    both completely
+    
+    * the keyboard works mostly (input, etc. are fine) but:
+        1. the CAPS-lock LED will be stuck in the on position (however, the
+        CAPS state itself toggles fine)
+        2. the XF86Audio{Raise/Lower}Volume keys don't work (they work before
+        suspend)
+        
+        output of `kbdcontrol -d` and `kbdcontrol -i` are identical before and
+        after suspend/resume
+    
+    * exactly once, it happened that the keyboard did not work at all (no
+    input) after resume until I switched to a different vty and back; once I
+    did, everything worked perfectly (i.e., even the caps/audio issue above did
+    not happen) - I am still trying to replicate this.
+
+1. bluetooth:
+      loading ng_ubt does not make any bluetooth devices visible (i.e., no
+      'ubt' related messages in /var/log/messages; like in FreeBSD Handbook
+      34.7.1. Loading Bluetooth Support)
+
+      I did not investigate any further
+
+1. hybrid NVidia MX350 dGPU:
+      the latest nvidia-drm-kmod pkg will *not* work (there will be kernel
+      messages telling you to downgrade), you need to install
+      nvidia-drm-kmod-580
+
+      however, even with nvidia-drm-kmod-580, sway wm (wlr) reports
+      /dev/dri/card0 as not being a DRM device
+
+      I could not investigate further and am just using the integrated Intel
+      GPU which works perfectly.
+
+1. the laptop appears to run perceptibly hotter than on Linux; I have no
+conjecture as to why.

--- a/test_results/Lenovo_ThinkPad_E15_Gen2/probe_2026-05-10_04-36-02.txt
+++ b/test_results/Lenovo_ThinkPad_E15_Gen2/probe_2026-05-10_04-36-02.txt
@@ -1,0 +1,132 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p8 releng/15.0-n281036-53054229dcb3 GENERIC
+Hardware: 20TDS0G500
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a49 subvendor=0x17aa subdevice=0x5088
+        vendor     = 'Intel Corporation'
+        device     = 'TigerLake-LP GT2 [Iris Xe Graphics]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: DETECTED
+    iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0f0 subvendor=0x8086 subdevice=0x0234
+        vendor     = 'Intel Corporation'
+        device     = 'Wi-Fi 6 AX201'
+        class      = network
+  Device 2 Status: WORKS
+    re0@pci0:4:0:0:	class=0x020000 rev=0x15 hdr=0x00 vendor=0x10ec device=0x8168 subvendor=0x17aa subdevice=0x5087
+        vendor     = 'Realtek Semiconductor Co., Ltd.'
+        device     = 'RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:31:3:	class=0x040100 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0c8 subvendor=0x17aa subdevice=0x5087
+        vendor     = 'Intel Corporation'
+        device     = 'Tiger Lake-LP Smart Sound Technology Audio Controller'
+        class      = multimedia
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:2:0:0:	class=0x010802 rev=0x01 hdr=0x00 vendor=0xc0a9 device=0x540a subvendor=0xc0a9 subdevice=0x540a
+        vendor     = 'Micron/Crucial Technology'
+        device     = 'P2 [Nick P2] / P3 / P3 Plus NVMe PCIe SSD (DRAM-less)'
+        class      = mass storage
+  Device 2 Status: DETECTED
+    nvme1@pci0:7:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa809 subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller 980 (DRAM-less)'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:13:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a13 subvendor=0x0000 subdevice=0x0000
+        vendor     = 'Intel Corporation'
+        device     = 'Tiger Lake-LP Thunderbolt 4 USB Controller'
+        class      = serial bus
+        subclass   = USB
+    none2@pci0:0:13:2:	class=0x0c0340 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a1b subvendor=0x2222 subdevice=0x1111
+        vendor     = 'Intel Corporation'
+        device     = 'Tiger Lake-LP Thunderbolt 4 NHI'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0ed subvendor=0x0000 subdevice=0x0000
+        vendor     = 'Intel Corporation'
+        device     = 'Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_ibm.ko
+acpi_wmi.ko
+coretemp.ko
+dmabuf.ko
+drm.ko
+hidmap.ko
+hms.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+lindebugfs.ko
+linuxkpi_video.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+nlsysevent.ko
+smbus.ko
+ttm.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            8
+Thread(s) per core:      2
+Core(s) per socket:      4
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   140
+Model name:              11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz
+Stepping:                1
+L1d cache:               48K
+L1i cache:               32K
+L2 cache:                1280K
+L3 cache:                8M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust bmi1 avx2 fp_dp smep bmi2 erms invpcid fpcsds pqe pat pse36 rdseed adx smap clflushopt clwb intel_pt sha umip pku ospke syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary

<Briefly describe what you tested.>

# System information

Laptop make/model:
`uname -a` output:

FreeBSD thinkpad 15.0-RELEASE-p8 FreeBSD 15.0-RELEASE-p8 releng/15.0-n281036-53054229dcb3 GENERIC amd64

# Tests Completed

FreeBSD thinkpad 15.0-RELEASE-p8 FreeBSD 15.0-RELEASE-p8 releng/15.0-n281036-53054229dcb3 GENERIC amd64

## Installation

- [X] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [X] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)
WiFi works fine, I did not test if it was WiFi 5 or some other version.

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)
NOT TESTED

- [X] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.
NOT TESTED

- [X] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)
Yes, `wpa_cli`, but I did not test it.

## Audio/Video

- [X] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [X] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)
Tested with firefox and web-apps.

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)
Could not get the Mozilla WebRTC test page to share my screen.

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.
NOT TESTED.

## Power

- [X] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)
No, closer to 2-4 hours; but that is mostly me having an old-ish laptop.

- [-] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)
By default, `hw.acpi.lid_switch_state` is set to `NONE`, so no; however, setting it to `S3` works but see below for caveat.

- [-] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)
Not entirely, see comments.md for detailed troubleshooting done.

## User Experience

- [X] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [X] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [-] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)
Volume buttons work except after resume from S3. Brightness buttons don't work at all.

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)
NOT TESTED

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)
NOT TESTED

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)
NOT TESTED

# Additional Info

see `comments.md` for some troubleshooting and further details