### PR TITLE
Add mechrevo Jiaolong 16 2025 model results

### DIFF
--- a/test_results/jiaolong_series/probe_2026-05-18_00-11-38.txt
+++ b/test_results/jiaolong_series/probe_2026-05-18_00-11-38.txt
@@ -11,14 +11,14 @@ Hardware: JIAOLONG Series
         device     = 'GB206M [GeForce RTX 5060 Max-Q / Mobile]'
         class      = display
         subclass   = VGA
-  Device 2 Status: WORKS
+  Device 2 Status: FAILED
     vgapci1@pci0:5:0:0:	class=0x030000 rev=0xd8 hdr=0x00 vendor=0x1002 device=0x164e subvendor=0x1d05 subdevice=0x5005
         vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
         device     = 'Raphael'
         class      = display
         subclass   = VGA
 
-  Category Total Score: 2/2
+  Category Total Score: 1/2
 
 --------------------
 

--- a/test_results/jiaolong_series/probe_2026-05-18_00-11-38.txt
+++ b/test_results/jiaolong_series/probe_2026-05-18_00-11-38.txt
@@ -1,0 +1,160 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE releng/15.0-n280995-7aedc8de6446 GENERIC
+Hardware: JIAOLONG Series
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci0@pci0:1:0:0:	class=0x030000 rev=0xa1 hdr=0x00 vendor=0x10de device=0x2d19 subvendor=0x1d05 subdevice=0x605c
+        vendor     = 'NVIDIA Corporation'
+        device     = 'GB206M [GeForce RTX 5060 Max-Q / Mobile]'
+        class      = display
+        subclass   = VGA
+  Device 2 Status: WORKS
+    vgapci1@pci0:5:0:0:	class=0x030000 rev=0xd8 hdr=0x00 vendor=0x1002 device=0x164e subvendor=0x1d05 subdevice=0x5005
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Raphael'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: FAILED
+    ppt0@pci0:2:0:0:	class=0x028000 rev=0x00 hdr=0x00 vendor=0x14c3 device=0x7922 subvendor=0x1a3b subdevice=0x5911
+        vendor     = 'MEDIATEK Corp.'
+        device     = 'MT7922 802.11ax PCI Express Wireless Network Adapter'
+        class      = network
+  Device 2 Status: DETECTED
+    none0@pci0:4:0:0:	class=0x020000 rev=0x05 hdr=0x00 vendor=0x10ec device=0x8125 subvendor=0x1d05 subdevice=0x7013
+        vendor     = 'Realtek Semiconductor Co., Ltd.'
+        device     = 'RTL8125 2.5GbE Controller'
+        class      = network
+
+  Category Total Score: 1/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:1:0:1:	class=0x040300 rev=0xa1 hdr=0x00 vendor=0x10de device=0x22eb subvendor=0x10de subdevice=0x0000
+        vendor     = 'NVIDIA Corporation'
+        device     = 'GB206 High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+    hdac1@pci0:5:0:1:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1002 device=0x1640 subvendor=0x1d05 subdevice=0x5005
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Radeon High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+    hdac2@pci0:5:0:6:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15e3 subvendor=0x1d05 subdevice=0x3010
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Ryzen HD Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:3:0:0:	class=0x010802 rev=0x03 hdr=0x00 vendor=0x1e49 device=0x1081 subvendor=0x1e49 subdevice=0x1081
+        vendor     = 'Yangtze Memory Technologies Co.,Ltd'
+        device     = 'PC41Q M.2 2280 NVMe SSD (DRAM-less)'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:5:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b6 subvendor=0x1d05 subdevice=0x5005
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Raphael/Granite Ridge USB 3.1 xHCI'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:5:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b7 subvendor=0x1d05 subdevice=0x5005
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Raphael/Granite Ridge USB 3.1 xHCI'
+        class      = serial bus
+        subclass   = USB
+    xhci2@pci0:6:0:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b8 subvendor=0x1d05 subdevice=0x5005
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Raphael/Granite Ridge USB 2.0 xHCI'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+amdsmn.ko
+amdtemp.ko
+bridgestp.ko
+fdescfs.ko
+fusefs.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+if_bridge.ko
+if_urndis.ko
+ig4.ko
+iichid.ko
+intpm.ko
+linprocfs.ko
+linsysfs.ko
+linux.ko
+linux64.ko
+linux_common.ko
+mac_ntpd.ko
+mqueuefs.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+nlsysevent.ko
+nmdm.ko
+nvidia-modeset.ko
+nvidia.ko
+pty.ko
+smbus.ko
+uether.ko
+vmm.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            32
+Thread(s) per core:      2
+Core(s) per socket:      16
+Socket(s):               1
+Vendor:                  AuthenticAMD
+CPU family:              25
+Model:                   97
+Model name:              AMD Ryzen 9 8940HX with Radeon Graphics        
+Stepping:                2
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                1024K
+L3 cache:                64M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh mmx fxsr sse sse2 htt sse3 pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 popcnt aes xsave osxsave avx f16c rdrnd syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm lahf_lm cmp_legacy svm extapic cr8_legacy lzcnt sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb pcx_l2i
+
+====================================


### PR DESCRIPTION
# Summary

- Headphone input
- 3 USB ports
- dGPU games & video 
- keyboard fn keys


# System information

Laptop make/model:mechrevo Jiaolong Series 16 2025 model(orange)
`uname -a` output:
`FreeBSD guihongBSD 15.0-RELEASE FreeBSD 15.0-RELEASE releng/15.0-n280995-7aedc8de6446 GENERIC amd64
`

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [X] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [X] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [X] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info

## network


[MT76XX kmod](https://cgit.freebsd.org/ports/tree/net/wifi-firmware-mt76-kmod) is not work on my laptop by using MT7922 

i have a rtl8188gu but the system didnt load it as wlan devices

## bluetooth 

mediatek bluetooth

bluetooth is not working either `USB\VID_13D3&PID_3585&REV_0100&MI_00`

## graphic 

We have dual graphic on mechine but when install drm-kmod on another graphic(Radeon 610M),it got kernel panic.

using nvdia property driver 595.71.05

## other 

microphone work fine 
camera failed `USB\VID_2B7E&PID_B651&REV_0005&MI_00`
i try wifibox for my mt7922 but failed because the iommu problem,so thats why i have ppt driver in my mt7922
when lid into the sleep mode it still running battrey as normal (althought screen turn down)


i use KDE 