### PR TITLE
Thinkpad X1 Carbon Gen 8 and Thinkpad X13 Gen 4 AMD

### DIFF
--- a/test_results/Thinkpad_X13_Gen_4_AMD/comments.md
+++ b/test_results/Thinkpad_X13_Gen_4_AMD/comments.md
@@ -1,0 +1,1 @@
+Builtin wifi didn't work so I had to use a usb wifi adapter.

--- a/test_results/Thinkpad_X13_Gen_4_AMD/probe_2026-05-23_16-27-30.txt
+++ b/test_results/Thinkpad_X13_Gen_4_AMD/probe_2026-05-23_16-27-30.txt
@@ -1,0 +1,163 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC
+Hardware: 21J3CTO1WW
+------------------------------------
+
+- Graphics
+  Device 1 Status: WORKS
+    vgapci0@pci0:195:0:0:	class=0x030000 rev=0xdd hdr=0x00 vendor=0x1002 device=0x15bf subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Phoenix1'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: FAILED
+    none5@pci0:1:0:0:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x17cb device=0x1103 subvendor=0x17aa subdevice=0x9309
+        vendor     = 'Qualcomm Technologies, Inc'
+        device     = 'QCNFA765 Wireless Network Adapter'
+        class      = network
+
+  Category Total Score: 0/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:195:0:1:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1002 device=0x1640 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Radeon High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+    hdac1@pci0:195:0:6:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15e3 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Ryzen HD Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:2:0:0:	class=0x010802 rev=0x01 hdr=0x00 vendor=0x1e0f device=0x0010 subvendor=0x1e0f subdevice=0x0001
+        vendor     = 'KIOXIA Corporation'
+        device     = 'NVMe SSD Controller XG8'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:195:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b9 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:195:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15ba subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    xhci2@pci0:197:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15c0 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    xhci3@pci0:197:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15c1 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        class      = serial bus
+        subclass   = USB
+    none11@pci0:197:0:5:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x1022 device=0x1668 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Pink Sardine USB4/Thunderbolt NHI controller'
+        class      = serial bus
+        subclass   = USB
+    none12@pci0:197:0:6:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x1022 device=0x1669 subvendor=0x17aa subdevice=0x50d0
+        vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+        device     = 'Pink Sardine USB4/Thunderbolt NHI controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_ibm.ko
+acpi_wmi.ko
+amdgpu.ko
+amdgpu_dcn_3_1_4_dmcub_bin.ko
+amdgpu_gc_11_0_1_imu_bin.ko
+amdgpu_gc_11_0_1_me_bin.ko
+amdgpu_gc_11_0_1_mec_bin.ko
+amdgpu_gc_11_0_1_mes1_bin.ko
+amdgpu_gc_11_0_1_mes_2_bin.ko
+amdgpu_gc_11_0_1_pfp_bin.ko
+amdgpu_gc_11_0_1_rlc_bin.ko
+amdgpu_psp_13_0_4_ta_bin.ko
+amdgpu_psp_13_0_4_toc_bin.ko
+amdgpu_sdma_6_0_1_bin.ko
+amdgpu_vcn_4_0_2_bin.ko
+autofs.ko
+dmabuf.ko
+drm.ko
+fdescfs.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+if_rtwn_usb.ko
+ig4.ko
+iic.ko
+iichid.ko
+intpm.ko
+lindebugfs.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+nlsysevent.ko
+rtwn.ko
+smbus.ko
+ttm.ko
+ucom.ko
+uplcom.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            16
+Thread(s) per core:      2
+Core(s) per socket:      8
+Socket(s):               1
+Vendor:                  AuthenticAMD
+CPU family:              25
+Model:                   116
+Model name:              AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics  
+Stepping:                1
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                1024K
+L3 cache:                16M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh mmx fxsr sse sse2 htt sse3 pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 popcnt aes xsave osxsave avx f16c rdrnd syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm lahf_lm cmp_legacy svm extapic cr8_legacy lzcnt sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb pcx_l2i
+
+====================================

--- a/test_results/Thinkpad_X1_Carbon_Gen_8/probe_2026-05-23_14-51-06.txt
+++ b/test_results/Thinkpad_X1_Carbon_Gen_8/probe_2026-05-23_14-51-06.txt
@@ -1,0 +1,133 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC
+Hardware: 20U9CTO1WW
+------------------------------------
+
+- Graphics
+  Device 1 Status: WORKS
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x02 hdr=0x00 vendor=0x8086 device=0x9b41 subvendor=0x17aa subdevice=0x22be
+        vendor     = 'Intel Corporation'
+        device     = 'CometLake-U GT2 [UHD Graphics]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02f0 subvendor=0x8086 subdevice=0x0070
+        vendor     = 'Intel Corporation'
+        device     = 'Comet Lake PCH-LP CNVi WiFi'
+        class      = network
+  Device 2 Status: DETECTED
+    em0@pci0:0:31:6:	class=0x020000 rev=0x00 hdr=0x00 vendor=0x8086 device=0x0d4f subvendor=0x17aa subdevice=0x22be
+        vendor     = 'Intel Corporation'
+        device     = 'Ethernet Connection (10) I219-V'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:31:3:	class=0x040380 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02c8 subvendor=0x17aa subdevice=0x22be
+        vendor     = 'Intel Corporation'
+        device     = 'Comet Lake PCH-LP cAVS'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:3:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa809 subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller 980 (DRAM-less)'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:20:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02ed subvendor=0x17aa subdevice=0x22be
+        vendor     = 'Intel Corporation'
+        device     = 'Comet Lake PCH-LP USB 3.1 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:45:0:0:	class=0x0c0330 rev=0x02 hdr=0x00 vendor=0x8086 device=0x15d4 subvendor=0x17aa subdevice=0x22be
+        vendor     = 'Intel Corporation'
+        device     = 'JHL6540 Thunderbolt 3 USB Controller (C step) [Alpine Ridge 4C 2016]'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_ibm.ko
+acpi_wmi.ko
+autofs.ko
+dmabuf.ko
+drm.ko
+fdescfs.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+lindebugfs.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+pchtherm.ko
+smbus.ko
+ttm.ko
+ucom.ko
+uplcom.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            8
+Thread(s) per core:      2
+Core(s) per socket:      4
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   142
+Model name:              Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz
+Stepping:                12
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                256K
+L3 cache:                6M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid fpcsds mpx rdseed adx smap clflushopt intel_pt syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary

Installed 15.0 from usb, updated, installed kde with desktop-installer script, tested sound and volume/brightness buttons.

# System information

Laptop make/model:
`uname -a` output:
thinkpad: FreeBSD thinkpad 15.0-RELEASE-p9 FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC amd64

x13: FreeBSD x13 15.0-RELEASE-p9 FreeBSD 15.0-RELEASE-p9 releng/15.0-n281048-6d536196f1bd GENERIC amd64

# Tests Completed

## Installation

- [x] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)
thinkpad: Installer works fine.  Desktop installer script works, but I had enable sddm with sysrc to get a gui login prompt at boot.

x13: Installer works fine.  Desktop installer script worked, I enabled sddm with sysrc but I don't get gui login at boot.  When I start the sddm service it gives an error about it not being enabled in rc.conf even though it is and I have to use onestart instead of start.

## Wireless
thinkpad:  Wireless card was detected during install, but had to add DHCP manually.

x13:  Builtin qualcom card not working, had to use usb realtek adapter.
 
- [x] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [x] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [x] I can change the keyboard backlight and display backlight to view at a comfortable brightness.
both yes
- [x] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)
both yes
- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)
thinkpad: volume and brightness buttons work, but mic mute and wifi button doesn't work

x13: no buttons work
- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info
