### PR TITLE
add test results for 5 Dell and HP laptops

### DIFF
--- a/test_results/dell_system_xps_l702x/probe_2026-04-07_12-42-20.txt
+++ b/test_results/dell_system_xps_l702x/probe_2026-04-07_12-42-20.txt
@@ -1,0 +1,124 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-STABLE stable/15-n282457-b642867c2cc7 GENERIC
+Hardware: Dell System XPS L702X
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci1@pci0:0:2:0:	class=0x030000 rev=0x09 hdr=0x00 vendor=0x8086 device=0x0116 subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'Intel Corporation'
+        device     = '2nd Generation Core Processor Family Integrated Graphics Controller'
+        class      = display
+        subclass   = VGA
+  Device 2 Status: DETECTED
+    vgapci0@pci0:1:0:0:	class=0x030000 rev=0xa1 hdr=0x00 vendor=0x10de device=0x0dcd subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'NVIDIA Corporation'
+        device     = 'GF106M [GeForce GT 555M]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: DETECTED
+    iwn0@pci0:3:0:0:	class=0x028000 rev=0x34 hdr=0x00 vendor=0x8086 device=0x0091 subvendor=0x8086 subdevice=0x5221
+        vendor     = 'Intel Corporation'
+        device     = 'Centrino Advanced-N 6230 [Rainbow Peak]'
+        class      = network
+  Device 2 Status: WORKS
+    re0@pci0:10:0:0:	class=0x020000 rev=0x06 hdr=0x00 vendor=0x10ec device=0x8168 subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'Realtek Semiconductor Co., Ltd.'
+        device     = 'RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:27:0:	class=0x040300 rev=0x05 hdr=0x00 vendor=0x8086 device=0x1c20 subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'Intel Corporation'
+        device     = '6 Series/C200 Series Chipset Family High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: WORKS
+    ahci0@pci0:0:31:2:	class=0x010601 rev=0x05 hdr=0x00 vendor=0x8086 device=0x1c03 subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'Intel Corporation'
+        device     = '6 Series/C200 Series Chipset Family 6 port Mobile SATA AHCI Controller'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    ehci0@pci0:0:26:0:	class=0x0c0320 rev=0x05 hdr=0x00 vendor=0x8086 device=0x1c2d subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'Intel Corporation'
+        device     = '6 Series/C200 Series Chipset Family USB Enhanced Host Controller'
+        class      = serial bus
+        subclass   = USB
+    ehci1@pci0:0:29:0:	class=0x0c0320 rev=0x05 hdr=0x00 vendor=0x8086 device=0x1c26 subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'Intel Corporation'
+        device     = '6 Series/C200 Series Chipset Family USB Enhanced Host Controller'
+        class      = serial bus
+        subclass   = USB
+    xhci0@pci0:4:0:0:	class=0x0c0330 rev=0x04 hdr=0x00 vendor=0x1033 device=0x0194 subvendor=0x1028 subdevice=0x04b8
+        vendor     = 'NEC Corporation'
+        device     = 'uPD720200 USB 3.0 Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+ichsmb.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+smbus.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            8
+Thread(s) per core:      2
+Core(s) per socket:      4
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   42
+Model name:              Intel(R) Core(TM) i7-2630QM CPU @ 2.00GHz
+Stepping:                7
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                256K
+L3 cache:                6M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic popcnt tsc_deadline xsave osxsave avx syscall nx rdtscp lm lahf_lm
+
+====================================

--- a/test_results/hp_envy_17_notebook_pc/comments.md
+++ b/test_results/hp_envy_17_notebook_pc/comments.md
@@ -1,0 +1,6 @@
+the broadcom wifi adapter does not work, but according 
+to bsd-hardware.info, it is supported by if_bwn_pci.c, 
+which seems to be in the GENERIC kernel.
+
+https://bsd-hardware.info/?probe=c280e17f04
+https://bsd-hardware.info/?id=pci:14e4-4353-103c-1509

--- a/test_results/hp_envy_17_notebook_pc/probe_2026-05-06_02-59-32.txt
+++ b/test_results/hp_envy_17_notebook_pc/probe_2026-05-06_02-59-32.txt
@@ -1,0 +1,135 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-BETA1 releng/15.1-n283455-58777180c5b0 GENERIC
+Hardware: HP ENVY 17 Notebook PC
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci0@pci0:1:0:0:	class=0x030000 rev=0x00 hdr=0x00 vendor=0x1002 device=0x68a1 subvendor=0x103c subdevice=0x144d
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Broadway PRO [Mobility Radeon HD 5850]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    bwn_pci0@pci0:2:0:0:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x14e4 device=0x4353 subvendor=0x103c subdevice=0x1509
+        vendor     = 'Broadcom Inc. and subsidiaries'
+        device     = 'BCM43224 802.11a/b/g/n'
+        class      = network
+  Device 2 Status: DETECTED
+    re0@pci0:3:0:0:	class=0x020000 rev=0x03 hdr=0x00 vendor=0x10ec device=0x8168 subvendor=0x103c subdevice=0x144d
+        vendor     = 'Realtek Semiconductor Co., Ltd.'
+        device     = 'RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac1@pci0:0:27:0:	class=0x040300 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b56 subvendor=0x103c subdevice=0x144d
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset High Definition Audio'
+        class      = multimedia
+        subclass   = HDA
+    hdac0@pci0:1:0:1:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1002 device=0xaa58 subvendor=0x103c subdevice=0x144d
+        vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+        device     = 'Juniper HDMI Audio [Radeon HD 5700 Series]'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: WORKS
+    ahci0@pci0:0:31:2:	class=0x010601 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b29 subvendor=0x103c subdevice=0x144d
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset 4 port SATA AHCI Controller'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    ehci0@pci0:0:26:0:	class=0x0c0320 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b3c subvendor=0x103c subdevice=0x144d
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset USB2 Enhanced Host Controller'
+        class      = serial bus
+        subclass   = USB
+    ehci1@pci0:0:29:0:	class=0x0c0320 rev=0x05 hdr=0x00 vendor=0x8086 device=0x3b34 subvendor=0x103c subdevice=0x144d
+        vendor     = 'Intel Corporation'
+        device     = '5 Series/3400 Series Chipset USB2 Enhanced Host Controller'
+        class      = serial bus
+        subclass   = USB
+    xhci0@pci0:4:0:0:	class=0x0c0330 rev=0x03 hdr=0x00 vendor=0x1033 device=0x0194 subvendor=0x103c subdevice=0x144d
+        vendor     = 'NEC Corporation'
+        device     = 'uPD720200 USB 3.0 Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+bcma.ko
+bcma_bhndb.ko
+bhnd.ko
+bhnd_pci.ko
+bhnd_pci_hostb.ko
+bhndb.ko
+bhndb_pci.ko
+gpiobus.ko
+hidmap.ko
+hms.ko
+ichsmb.ko
+if_bwn.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+siba.ko
+siba_bhndb.ko
+smbus.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            8
+Thread(s) per core:      2
+Core(s) per socket:      4
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   30
+Model name:              Intel(R) Core(TM) i7 CPU       Q 720  @ 1.60GHz
+Stepping:                5
+L1d cache:               32K
+L1i cache:               32K
+L3 cache:                6M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 dtes64 monitor ds_cpl vmx smx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 popcnt syscall nx rdtscp lm lahf_lm
+
+====================================

--- a/test_results/inspiron_3543/probe_2026-05-06_04-47-46.txt
+++ b/test_results/inspiron_3543/probe_2026-05-06_04-47-46.txt
@@ -1,0 +1,121 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-BETA1 releng/15.1-n283455-58777180c5b0 GENERIC
+Hardware: Inspiron 3543
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x09 hdr=0x00 vendor=0x8086 device=0x1616 subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Intel Corporation'
+        device     = 'Broadwell-U GT2 [HD Graphics 5500]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    none1@pci0:6:0:0:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x14e4 device=0x4365 subvendor=0x1028 subdevice=0x0016
+        vendor     = 'Broadcom Inc. and subsidiaries'
+        device     = 'BCM43142 802.11b/g/n'
+        class      = network
+  Device 2 Status: FAILED
+    re0@pci0:7:0:0:	class=0x020000 rev=0x07 hdr=0x00 vendor=0x10ec device=0x8136 subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Realtek Semiconductor Co., Ltd.'
+        device     = 'RTL810xE PCI Express Fast Ethernet controller'
+        class      = network
+
+  Category Total Score: 1/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:3:0:	class=0x040300 rev=0x09 hdr=0x00 vendor=0x8086 device=0x160c subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Intel Corporation'
+        device     = 'Broadwell-U Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+    hdac1@pci0:0:27:0:	class=0x040300 rev=0x03 hdr=0x00 vendor=0x8086 device=0x9ca0 subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Intel Corporation'
+        device     = 'Wildcat Point-LP High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: WORKS
+    ahci0@pci0:0:31:2:	class=0x010601 rev=0x03 hdr=0x00 vendor=0x8086 device=0x9c83 subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Intel Corporation'
+        device     = 'Wildcat Point-LP SATA Controller [AHCI Mode]'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:20:0:	class=0x0c0330 rev=0x03 hdr=0x00 vendor=0x8086 device=0x9cb1 subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Intel Corporation'
+        device     = 'Wildcat Point-LP USB xHCI Controller'
+        class      = serial bus
+        subclass   = USB
+    ehci0@pci0:0:29:0:	class=0x0c0320 rev=0x03 hdr=0x00 vendor=0x8086 device=0x9ca6 subvendor=0x1028 subdevice=0x0654
+        vendor     = 'Intel Corporation'
+        device     = 'Wildcat Point-LP USB EHCI Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+hconf.ko
+hmt.ko
+ichsmb.ko
+ig4.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+smbus.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            4
+Thread(s) per core:      2
+Core(s) per socket:      2
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   61
+Model name:              Intel(R) Core(TM) i5-5200U CPU @ 2.20GHz
+Stepping:                4
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                256K
+L3 cache:                3M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid fpcsds rdseed adx smap intel_pt syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================

--- a/test_results/xps_17_9700/probe_2026-05-05_11-54-40.txt
+++ b/test_results/xps_17_9700/probe_2026-05-05_11-54-40.txt
@@ -1,0 +1,164 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE-p6 GENERIC
+Hardware: XPS 17 9700
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci1@pci0:0:2:0:	class=0x030000 rev=0x05 hdr=0x00 vendor=0x8086 device=0x9bc4 subvendor=0x1028 subdevice=0x098f
+        vendor     = 'Intel Corporation'
+        device     = 'CometLake-H GT2 [UHD Graphics]'
+        class      = display
+        subclass   = VGA
+  Device 2 Status: WORKS
+    vgapci0@pci0:1:0:0:	class=0x030000 rev=0xa1 hdr=0x00 vendor=0x10de device=0x1f12 subvendor=0x1028 subdevice=0x098f
+        vendor     = 'NVIDIA Corporation'
+        device     = 'TU106M [GeForce RTX 2060 Max-Q]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x00 hdr=0x00 vendor=0x8086 device=0x06f0 subvendor=0x1a56 subdevice=0x1651
+        vendor     = 'Intel Corporation'
+        device     = 'Comet Lake PCH CNVi WiFi'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:1:0:1:	class=0x040300 rev=0xa1 hdr=0x00 vendor=0x10de device=0x10f9 subvendor=0x1028 subdevice=0x098f
+        vendor     = 'NVIDIA Corporation'
+        device     = 'TU106 High Definition Audio Controller'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    nvme0@pci0:2:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa808 subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller SM981/PM981/PM983'
+        class      = mass storage
+  Device 2 Status: DETECTED
+    nvme1@pci0:3:0:0:	class=0x010802 rev=0x01 hdr=0x00 vendor=0x144d device=0xa802 subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller SM951/PM951'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x8086 device=0x06ed subvendor=0x1028 subdevice=0x098f
+        vendor     = 'Intel Corporation'
+        device     = 'Comet Lake USB 3.1 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+    xhci0@pci0:1:0:2:	class=0x0c0330 rev=0xa1 hdr=0x00 vendor=0x10de device=0x1ada subvendor=0x1028 subdevice=0x098f
+        vendor     = 'NVIDIA Corporation'
+        device     = 'TU106 USB 3.1 Host Controller'
+        class      = serial bus
+        subclass   = USB
+    xhci2@pci0:59:0:0:	class=0x0c0330 rev=0x06 hdr=0x00 vendor=0x8086 device=0x15ec subvendor=0x1028 subdevice=0x098f
+        vendor     = 'Intel Corporation'
+        device     = 'JHL7540 Thunderbolt 3 USB Controller [Titan Ridge 4C 2018]'
+        class      = serial bus
+        subclass   = USB
+    xhci3@pci0:165:0:0:	class=0x0c0330 rev=0x06 hdr=0x00 vendor=0x8086 device=0x15ec subvendor=0x1028 subdevice=0x098f
+        vendor     = 'Intel Corporation'
+        device     = 'JHL7540 Thunderbolt 3 USB Controller [Titan Ridge 4C 2018]'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_dock.ko
+acpi_wmi.ko
+autofs.ko
+coretemp.ko
+cpuctl.ko
+cryptodev.ko
+cuse.ko
+dmabuf.ko
+drm.ko
+fdescfs.ko
+fusefs.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+lindebugfs.ko
+linprocfs.ko
+linsysfs.ko
+linux.ko
+linux64.ko
+linux_common.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+mqueuefs.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+nvidia-modeset.ko
+nvidia.ko
+pchtherm.ko
+pty.ko
+rtsx.ko
+smbus.ko
+ttm.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            16
+Thread(s) per core:      2
+Core(s) per socket:      8
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   165
+Model name:              Intel(R) Core(TM) i7-10875H CPU @ 2.30GHz
+Stepping:                2
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                256K
+L3 cache:                16M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid fpcsds mpx rdseed adx smap clflushopt intel_pt pku ospke sgx_lc syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================

--- a/test_results/xps_17_9730/probe_2026-05-04_10-39-05.txt
+++ b/test_results/xps_17_9730/probe_2026-05-04_10-39-05.txt
@@ -1,0 +1,144 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.0-RELEASE releng/15.0-n280995-7aedc8de6446 GENERIC
+Hardware: XPS 17 9730
+------------------------------------
+
+- Graphics
+  Device 1 Status: DETECTED
+    vgapci1@pci0:0:2:0:	class=0x030000 rev=0x04 hdr=0x00 vendor=0x8086 device=0xa7a0 subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P [Iris Xe Graphics]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: WORKS
+    iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51f1 subvendor=0x8086 subdevice=0x4090
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake PCH CNVi WiFi'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:31:3:	class=0x040100 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51ca subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P/U/H cAVS'
+        class      = multimedia
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: DETECTED
+    pcib6@pci0:0:14:0:	class=0x010400 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa77f subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Volume Management Device NVMe RAID Controller Intel Corporation'
+        class      = mass storage
+  Device 2 Status: DETECTED
+    nvme0@pci65529:225:0:0:	class=0x010802 rev=0x01 hdr=0x00 vendor=0x15b7 device=0x5011 subvendor=0x15b7 subdevice=0x5011
+        vendor     = 'Sandisk Corp'
+        device     = 'WD PC SN810 / Black SN850 NVMe SSD'
+        class      = mass storage
+  Device 3 Status: DETECTED
+    nvme1@pci65529:226:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa80d subvendor=0x144d subdevice=0xa801
+        vendor     = 'Samsung Electronics Co Ltd'
+        device     = 'NVMe SSD Controller PM9C1a (DRAM-less)'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:13:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa71e subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P Thunderbolt 4 USB Controller'
+        class      = serial bus
+        subclass   = USB
+    none4@pci0:0:13:2:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa73e subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P Thunderbolt 4 NHI'
+        class      = serial bus
+        subclass   = USB
+    none5@pci0:0:13:3:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x8086 device=0xa76d subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Raptor Lake-P Thunderbolt 4 NHI'
+        class      = serial bus
+        subclass   = USB
+    xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x51ed subvendor=0x1028 subdevice=0x0bda
+        vendor     = 'Intel Corporation'
+        device     = 'Alder Lake PCH USB 3.2 xHCI Host Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+dmabuf.ko
+drm.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+lindebugfs.ko
+linux.ko
+linux_common.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+mqueuefs.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+nvidia.ko
+rtsx.ko
+smbus.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            20
+Thread(s) per core:      2
+Core(s) per socket:      10
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   186
+Model name:              13th Gen Intel(R) Core(TM) i9-13900H
+Stepping:                2
+L1d cache:               48K
+L1i cache:               32K
+L2 cache:                1280K
+L3 cache:                24M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust bmi1 avx2 fp_dp smep bmi2 erms invpcid fpcsds rdseed adx smap clflushopt clwb intel_pt umip pku ospke syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary

I installed FreeBSD 15.x and ran thet test script.  

# System information

Laptop make/model:
`uname -a` output:

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info
