### PR TITLE
Add test results for Lenovo ThinkPad X1 Carbon Gen 4 (20FB0069MN)

### DIFF
--- a/test_results/20FB0069MN/comments.md
+++ b/test_results/20FB0069MN/comments.md
@@ -1,0 +1,49 @@
+# User experience notes - ThinkPad X1 Carbon Gen 4 (20FB0069MN)
+
+Tested with KDE Plasma 6 (X11 session) on top of SDDM, FreeBSD 15.1-RELEASE.
+
+## Display power management (DPMS) causes a full system hang
+Setting Plasma's "Turn off screen" timeout (Power Management settings)
+causes a complete system freeze requiring a hard reboot. This appears
+related to known i915kms/drm-kmod display power-state issues on this
+chipset (Intel HD Graphics 520 / Skylake-U). Workaround: leave
+"Turn off screen" set to "Do nothing".
+
+## Suspend (S3) works, but is hidden from the Plasma UI
+`acpiconf -s 3` suspends and resumes the laptop correctly. However,
+Plasma's Power Management page does not offer a "Suspend" option at
+all, and ConsoleKit2's `CanSuspend` D-Bus method incorrectly returns
+"no". Root cause: PowerDevil registers its own inhibitor with the
+reason string `handle-suspend-key`, and ConsoleKit2 appears to treat
+the substring "suspend" in any active inhibitor as a real block on
+suspending - even though this is PowerDevil's own, expected
+inhibitor. This means suspend is unusable from the GUI on a stock
+setup, despite working perfectly at the hardware/kernel level.
+
+Workaround used: a sudoers NOPASSWD rule for `/usr/sbin/acpiconf -s 3`
+combined with a custom KDE global shortcut. For lid-close and
+inactivity-based suspend, a custom devd(8) script with a delay timer
+was used instead of Plasma's built-in suspend handling.
+
+## Shutdown/Restart missing from Plasma's logout menu
+By default, ConsoleKit2 reports `active = FALSE` for the X11/SDDM
+session (`ck-list-sessions`), even after adding `pam_ck_connector.so`
+to SDDM's PAM session stack. As a result, PowerDevil hides the
+Shutdown/Restart buttons. Workaround: a custom polkit rule granting
+`wheel` group members the `org.freedesktop.consolekit.system.stop`
+and `.restart` actions directly, bypassing the broken active-session
+check.
+
+## Wi-Fi works at the driver level, but KDE's "Wi-Fi & Internet"
+## settings page shows no networks
+The `iwm0` (Intel Wireless 8260) device works fine at the driver
+level. However, KDE's native Wi-Fi system settings page (plasma-nm)
+never shows any networks, because the real freedesktop.org
+NetworkManager daemon it depends on is not available on FreeBSD.
+Workaround: installed `networkmgr` (the GhostBSD tray-icon network
+manager) as a separate application instead.
+
+## Bluetooth
+Reported as NOT DETECTED by the probe tool, despite `ng_bluetooth`,
+`ng_hci`, and `ng_ubt` kernel modules being loaded. Not investigated
+further in this session.

--- a/test_results/20FB0069MN/probe_2026-06-25_21-45-08.txt
+++ b/test_results/20FB0069MN/probe_2026-06-25_21-45-08.txt
@@ -1,0 +1,129 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-RELEASE releng/15.1-n283562-96841ea08dcf GENERIC
+Hardware: 20FB0069MN
+------------------------------------
+
+- Graphics
+  Device 1 Status: WORKS
+    vgapci0@pci0:0:2:0:	class=0x030000 rev=0x07 hdr=0x00 vendor=0x8086 device=0x1916 subvendor=0x17aa subdevice=0x2238
+        vendor     = 'Intel Corporation'
+        device     = 'Skylake-U GT2 [HD Graphics 520]'
+        class      = display
+        subclass   = VGA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Networking
+  Device 1 Status: DETECTED
+    em0@pci0:0:31:6:	class=0x020000 rev=0x21 hdr=0x00 vendor=0x8086 device=0x1570 subvendor=0x17aa subdevice=0x2233
+        vendor     = 'Intel Corporation'
+        device     = 'Ethernet Connection I219-V'
+        class      = network
+  Device 2 Status: WORKS
+    iwm0@pci0:4:0:0:	class=0x028000 rev=0x3a hdr=0x00 vendor=0x8086 device=0x24f3 subvendor=0x8086 subdevice=0x1130
+        vendor     = 'Intel Corporation'
+        device     = 'Wireless 8260'
+        class      = network
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Audio
+    hdac0@pci0:0:31:3:	class=0x040300 rev=0x21 hdr=0x00 vendor=0x8086 device=0x9d70 subvendor=0x17aa subdevice=0x2238
+        vendor     = 'Intel Corporation'
+        device     = 'Sunrise Point-LP HD Audio'
+        class      = multimedia
+        subclass   = HDA
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Storage
+  Device 1 Status: WORKS
+    ahci0@pci0:0:23:0:	class=0x010601 rev=0x21 hdr=0x00 vendor=0x8086 device=0x9d03 subvendor=0x17aa subdevice=0x2238
+        vendor     = 'Intel Corporation'
+        device     = 'Sunrise Point-LP SATA Controller [AHCI mode]'
+        class      = mass storage
+
+  Category Total Score: 2/2
+
+--------------------
+
+- USB Ports
+    xhci0@pci0:0:20:0:	class=0x0c0330 rev=0x21 hdr=0x00 vendor=0x8086 device=0x9d2f subvendor=0x17aa subdevice=0x2238
+        vendor     = 'Intel Corporation'
+        device     = 'Sunrise Point-LP USB 3.0 xHCI Controller'
+        class      = serial bus
+        subclass   = USB
+
+  Category Total Score: 2/2
+
+--------------------
+
+- Bluetooth
+  Status: NOT DETECTED
+  Category Total Score: 0/2
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+cuse.ko
+dmabuf.ko
+drm.ko
+fdescfs.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwm.ko
+iic.ko
+lindebugfs.ko
+linprocfs.ko
+linsysfs.ko
+linux.ko
+linux64.ko
+linux_common.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+mqueuefs.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+pchtherm.ko
+pty.ko
+rtsx.ko
+smbus.ko
+ttm.ko
+u3g.ko
+ucom.ko
+zfs.ko
+====================================
+
+- CPU Info
+Architecture:            amd64
+Byte Order:              Little Endian
+Total CPU(s):            4
+Thread(s) per core:      2
+Core(s) per socket:      2
+Socket(s):               1
+Vendor:                  GenuineIntel
+CPU family:              6
+Model:                   78
+Model name:              Intel(R) Core(TM) i7-6500U CPU @ 2.50GHz
+Stepping:                3
+L1d cache:               32K
+L1i cache:               32K
+L2 cache:                256K
+L3 cache:                4M
+Flags:                   fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 cflsh ds acpi mmx fxsr sse sse2 ss htt tm pbe sse3 pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline aes xsave osxsave avx f16c rdrnd fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid fpcsds mpx rdseed adx smap clflushopt intel_pt syscall nx pdpe1gb rdtscp lm lahf_lm lzcnt
+
+====================================


### PR DESCRIPTION
# Summary
Laptop make/model:** Lenovo ThinkPad X1 Carbon Gen 4 (20FB0069MN)
# System information
Laptop make/model: Lenovo ThinkPad X1 Carbon Gen 4 (20FB0069MN)
`uname -a` output:
FreeBSD FreeBSDx1 15.1-RELEASE FreeBSD 15.1-RELEASE releng/15.1-n283562-96841ea08dcf GENERIC amd64
# Tests Completed
## Installation
- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)
## Wireless
- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)
- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)
- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)
- [ ] I can connect my laptop to the internet by tethering with my mobile phone.
- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)
## Audio/Video
- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)
- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)
- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)
- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.
## Power
- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)
- [x] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)
    *Note: only works after adding a custom devd(8) script with a delay timer — not out of the box. See comments.md.*
- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)
## User Experience
- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.
- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)
- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)
- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)
## Virtualization
- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)
- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)
# Additional Info
See `comments.md` in `test_results/20FB0069MN/` for detailed findings, including:
- DPMS screen-off ("Turn off screen" in Power Management) causes a full system hang, likely related to known i915kms/drm-kmod display power-state issues on this chipset (Intel HD Graphics 520 / Skylake-U).
- Suspend (S3) works correctly at the kernel level (`acpiconf -s 3`), but Plasma's Power Management page does not offer a Suspend option at all. Root cause: ConsoleKit2's `CanSuspend` D-Bus method incorrectly returns "no" because it appears to treat PowerDevil's own `handle-suspend-key` inhibitor as a real block. Worked around with a sudoers NOPASSWD rule + custom KDE global shortcut for manual suspend, and a custom devd(8) script for lid-close/inactivity-based suspend.
- Shutdown/Restart options are missing from Plasma's logout menu by default. ConsoleKit2 reports `active = FALSE` for the X11/SDDM session even after adding `pam_ck_connector.so` to SDDM's PAM stack. Worked around with a custom polkit rule granting the `wheel` group the `org.freedesktop.consolekit.system.stop`/`.restart` actions directly.
- KDE's native "Wi-Fi & Internet" settings page shows no networks, since the real freedesktop.org NetworkManager (which plasma-nm depends on) is not available on FreeBSD. Used GhostBSD's standalone `networkmgr` tray application instead, which works well once manually installed.
- Bluetooth reported as NOT DETECTED by the hw-probe tool, despite `ng_bluetooth`/`ng_hci`/`ng_ubt` kernel modules being loaded. Not investigated further.
