### PR TITLE
update new hwinfo and comment for mechrevo Jiaolong 16 pro 2025 model

### DIFF
--- a/test_results/Mechrevo_JIAOLONG_Dragon_16_Pro_2025/comments.md
+++ b/test_results/Mechrevo_JIAOLONG_Dragon_16_Pro_2025/comments.md
@@ -1,0 +1,21 @@
+# Notes
+
+Mechrevo JiaoLong Series 16 Pro(2025 Edition)Orange SKU(X6xR55xK-B2),as known as the same model like Tuxedo Stellaris 16[2] (uniwill IDK for the mother model)[1]
+
+## Display/Display
+
+Nvidia driver(offical UNIX driver 610.43.02 ) worked. with kld_list`nvidia nvidia-modeset`
+
+about AMDgpu just load correctly, but i didnt test it yet,because the dual gpu on my mechine and lack the experience for Configure X11.
+
+Backlight setting work while enable acpi_video  but only setting Backlight by `xbacklight` 
+
+## Wi-Fi
+
+Wifi is not working with the WIP driver[3],which in state 3.
+
+
+
+[1]: https://www.uniwill.com.tw/?page_id=16879
+[2]: https://www.tuxedocomputers.com/en/TUXEDO-Stellaris-16-Gen7-AMD.tuxedo
+[3]: https://wiki.freebsd.org/WiFi/Mt76

--- a/test_results/Mechrevo_JIAOLONG_Dragon_16_Pro_2025/probe_2026-08-11_22-51-00.txt
+++ b/test_results/Mechrevo_JIAOLONG_Dragon_16_Pro_2025/probe_2026-08-11_22-51-00.txt
@@ -1,0 +1,161 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-RELEASE GENERIC
+Hardware: JIAOLONG_Series
+CPU: AMD Ryzen 9 8940HX with Radeon Graphics        
+------------------------------------
+
+- Graphics
+vgapci0@pci0:1:0:0:	class=0x030000 rev=0xa1 hdr=0x00 vendor=0x10de device=0x2d19 subvendor=0x1d05 subdevice=0x605c
+    vendor     = 'NVIDIA Corporation'
+    device     = 'GB206M [GeForce RTX 5060 Max-Q / Mobile]'
+    class      = display
+    subclass   = VGA
+vgapci1@pci0:5:0:0:	class=0x030000 rev=0xd8 hdr=0x00 vendor=0x1002 device=0x164e subvendor=0x1d05 subdevice=0x5005
+    vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+    device     = 'Raphael'
+    class      = display
+    subclass   = VGA
+
+  Category Total Score: 1.5/2.0
+
+--------------------
+
+- Networking
+mt79210@pci0:2:0:0:	class=0x028000 rev=0x00 hdr=0x00 vendor=0x14c3 device=0x7922 subvendor=0x1a3b subdevice=0x5911
+    vendor     = 'MEDIATEK Corp.'
+    device     = 'MT7922 802.11ax PCI Express Wireless Network Adapter'
+    class      = network
+none1@pci0:4:0:0:	class=0x020000 rev=0x05 hdr=0x00 vendor=0x10ec device=0x8125 subvendor=0x1d05 subdevice=0x7013
+    vendor     = 'Realtek Semiconductor Co., Ltd.'
+    device     = 'RTL8125 2.5GbE Controller'
+    class      = network
+    subclass   = ethernet
+
+  Category Total Score: 0.5/2.0
+
+--------------------
+
+- Audio
+hdac0@pci0:1:0:1:	class=0x040300 rev=0xa1 hdr=0x00 vendor=0x10de device=0x22eb subvendor=0x10de subdevice=0x0000
+    vendor     = 'NVIDIA Corporation'
+    device     = 'GB206 High Definition Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+hdac1@pci0:5:0:1:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1002 device=0x1640 subvendor=0x1d05 subdevice=0x5005
+    vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+    device     = 'Radeon High Definition Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+none3@pci0:5:0:5:	class=0x048000 rev=0x62 hdr=0x00 vendor=0x1022 device=0x15e2 subvendor=0x1d05 subdevice=0x5005
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Audio Coprocessor'
+    class      = multimedia
+hdac2@pci0:5:0:6:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15e3 subvendor=0x1d05 subdevice=0x3010
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Ryzen HD Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+
+  Category Total Score: 1.5/2.0
+
+--------------------
+
+- Storage
+nvme0@pci0:3:0:0:	class=0x010802 rev=0x03 hdr=0x00 vendor=0x1e49 device=0x1081 subvendor=0x1e49 subdevice=0x1081
+    vendor     = 'Yangtze Memory Technologies Co.,Ltd'
+    device     = 'PC41Q M.2 2280 NVMe SSD (DRAM-less)'
+    class      = mass storage
+    subclass   = NVM
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- USB Ports
+xhci0@pci0:5:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b6 subvendor=0x1d05 subdevice=0x5005
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Raphael/Granite Ridge USB 3.1 xHCI'
+    class      = serial bus
+    subclass   = USB
+xhci1@pci0:5:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b7 subvendor=0x1d05 subdevice=0x5005
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Raphael/Granite Ridge USB 3.1 xHCI'
+    class      = serial bus
+    subclass   = USB
+xhci2@pci0:6:0:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15b8 subvendor=0x1d05 subdevice=0x5005
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Raphael/Granite Ridge USB 2.0 xHCI'
+    class      = serial bus
+    subclass   = USB
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Bluetooth
+
+
+
+  Category Total Score: 0.0/2.0
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_video.ko
+acpi_wmi.ko
+amdgpu.ko
+amdgpu_dcn_3_1_5_dmcub_bin.ko
+amdgpu_gc_10_3_6_ce_bin.ko
+amdgpu_gc_10_3_6_me_bin.ko
+amdgpu_gc_10_3_6_mec2_bin.ko
+amdgpu_gc_10_3_6_mec_bin.ko
+amdgpu_gc_10_3_6_pfp_bin.ko
+amdgpu_gc_10_3_6_rlc_bin.ko
+amdgpu_psp_13_0_5_ta_bin.ko
+amdgpu_psp_13_0_5_toc_bin.ko
+amdgpu_sdma_5_2_6_bin.ko
+amdgpu_vcn_3_1_2_bin.ko
+dmabuf.ko
+drm.ko
+fdescfs.ko
+fusefs.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+if_mt7921.ko
+if_urndis.ko
+ig4.ko
+iic.ko
+iichid.ko
+intpm.ko
+kernel
+lindebugfs.ko
+linprocfs.ko
+linsysfs.ko
+linux.ko
+linux64.ko
+linux_common.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+mqueuefs.ko
+mt76_core.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+nlsysevent.ko
+nvidia-modeset.ko
+nvidia.ko
+pty.ko
+smbus.ko
+ttm.ko
+uether.ko
+
+====================================


### PR DESCRIPTION
# Summary

backlight control,WIP mt7922 network driver and AMDgpu driver 

# System information

Laptop make/model:Mechrevo X6xR55xK-B2
`uname -a` output:FreeBSD 15.1-RELEASE GENERIC

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [x] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [x] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [x] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [x] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info
