### PR TITLE
Tests Lenovo Thinkpad T14 Gen 2

### DIFF
--- a/test_results/20W1S29800/probe_2026-08-26_20-12-05.txt
+++ b/test_results/20W1S29800/probe_2026-08-26_20-12-05.txt
@@ -1,0 +1,121 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-RELEASE-p2 stopgap-15.1-n283597-91c073bf54ad GENERIC
+Hardware: 20W1S29800
+CPU: 11th Gen Intel(R) Core(TM) i5-1145G7 @ 2.60GHz
+------------------------------------
+
+- Graphics
+vgapci0@pci0:0:2:0:	class=0x030000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a49 subvendor=0x17aa subdevice=0x22c9
+    vendor     = 'Intel Corporation'
+    device     = 'TigerLake-LP GT2 [Iris Xe Graphics]'
+    class      = display
+    subclass   = VGA
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Networking
+iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0f0 subvendor=0x8086 subdevice=0x0070
+    vendor     = 'Intel Corporation'
+    device     = 'Wi-Fi 6 AX201'
+    class      = network
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Audio
+hdac0@pci0:0:31:3:	class=0x040380 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0c8 subvendor=0x17aa subdevice=0x22c9
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Smart Sound Technology Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Storage
+nvme0@pci0:4:0:0:	class=0x010802 rev=0x03 hdr=0x00 vendor=0x8086 device=0xf1a6 subvendor=0x8086 subdevice=0x390b
+    vendor     = 'Intel Corporation'
+    device     = 'SSD DC P4101/Pro 7600p/760p/E 6100p Series'
+    class      = mass storage
+    subclass   = NVM
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- USB Ports
+xhci0@pci0:0:13:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a13 subvendor=0x17aa subdevice=0x22c9
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Thunderbolt 4 USB Controller'
+    class      = serial bus
+    subclass   = USB
+none1@pci0:0:13:2:	class=0x0c0340 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a1b subvendor=0x17aa subdevice=0x22c9
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Thunderbolt 4 NHI'
+    class      = serial bus
+    subclass   = USB
+none2@pci0:0:13:3:	class=0x0c0340 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a1d subvendor=0x17aa subdevice=0x22c9
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Thunderbolt 4 NHI'
+    class      = serial bus
+    subclass   = USB
+xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0ed subvendor=0x17aa subdevice=0x22c9
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller'
+    class      = serial bus
+    subclass   = USB
+
+  Category Total Score: 1.0/2.0
+
+--------------------
+
+- Bluetooth
+
+ugen1.4: <AX201 Bluetooth Intel Corp.> at usbus1, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (100mA)
+  bDeviceClass = 0x00e0  <Wireless controller>
+  bDeviceSubClass = 0x0001 
+  iManufacturer = 0x0000  <no string>
+  iProduct = 0x0000  <no string>
+  device = 'AX201 Bluetooth Intel Corp.'
+
+  Category Total Score: 0.0/2.0
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_ibm.ko
+acpi_wmi.ko
+cryptodev.ko
+dmabuf.ko
+drm.ko
+hconf.ko
+hmt.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+kernel
+lindebugfs.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+nullfs.ko
+smbus.ko
+ttm.ko
+zfs.ko
+
+====================================


### PR DESCRIPTION
Pretty solid laptop with fairly minimal, and well
documented, bugs.

Notable issues around the WiFi card recovery after moving to S3. It _was_ requiring a `$ doas service netif restart` with a cherry pick of `91c073bf54adadd4318b8bb088423654d1d1703a` on top of `releng/15.1`.

I am able to build a kernel that fixes this issue.

# Summary

<Briefly describe what you tested.>

# System information

Laptop make/model:
`uname -a` output:

# Tests Completed

## Installation

- [ ] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [ ] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info
