### PR TITLE
Add: Thinkpad X1 Yoga Gen 6 FreeBSD 15.1-REL test results

### DIFF
--- a/test_results/Lenovo_ThinkPad_X1_Yoga_Gen_6/comments.md
+++ b/test_results/Lenovo_ThinkPad_X1_Yoga_Gen_6/comments.md
@@ -1,0 +1,45 @@
+# Additional testing notes
+
+## FreeBSD version
+
+FreeBSD 15.1-RELEASE amd64, fresh install from distrubution sets
+
+## Wireless networking
+
+Built-in Intel wireless adapter associates successfully with 802.11ac access point with iwlwifi.
+
+However, the interface does not seem to be able to pass usable network traffic.
+
+Observed:
+
+- scanning works
+- WPA2 association succeeds
+- interface reports "status: associated"
+- DHCP repeatedly sends DHCPDISCOVER but doesn't receive a lease
+- manual IP configuration and adding default route doesn't result in usable network traffic
+- USB ethernet adapter ue0 worked on same network
+
+Also tested on 15.1-STABLE.
+
+Disabling HT / VHT allowed connectivity on another network (/boot/loader.conf.d/iwlwifi.conf):
+
+```
+compat.linuxkpi.80211.hw_crypto=1
+compat.linuxkpi.iwlwifi_11n_disable=1
+compat.linuxkpi.iwlwifi_disable_11n=0
+compat.linuxkpi.iwlwifi_disable_11ac=1
+```
+
+
+```
+iwlwifi0@pci0:0:20:3:   class=0x028000 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0f0 subvendor=0x8086 subdevice=0x0070
+    vendor     = 'Intel Corporation'
+    device     = 'Wi-Fi 6 AX201'
+    class      = network
+ 
+7    1 0xffffffff83ce6000    c4498 if_iwlwifi.ko
+ 8    1 0xffffffff83dab000    181b0 if_iwx.ko
+
+15.1-RELEASE
+```
+

--- a/test_results/Lenovo_ThinkPad_X1_Yoga_Gen_6/probe_2026-09-02_10-42-52.txt
+++ b/test_results/Lenovo_ThinkPad_X1_Yoga_Gen_6/probe_2026-09-02_10-42-52.txt
@@ -1,0 +1,117 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-RELEASE releng/15.1-n283562-96841ea08dcf GENERIC
+Hardware: 20Y0S0UM00
+CPU: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
+------------------------------------
+
+- Graphics
+vgapci0@pci0:0:2:0:	class=0x030000 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a49 subvendor=0x17aa subdevice=0x22d4
+    vendor     = 'Intel Corporation'
+    device     = 'TigerLake-LP GT2 [Iris Xe Graphics]'
+    class      = display
+    subclass   = VGA
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Networking
+iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0f0 subvendor=0x8086 subdevice=0x0070
+    vendor     = 'Intel Corporation'
+    device     = 'Wi-Fi 6 AX201'
+    class      = network
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Audio
+hdac0@pci0:0:31:3:	class=0x040380 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0c8 subvendor=0x17aa subdevice=0x22d4
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Smart Sound Technology Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Storage
+nvme0@pci0:4:0:0:	class=0x010802 rev=0x01 hdr=0x00 vendor=0x1344 device=0x5411 subvendor=0x1344 subdevice=0x2100
+    vendor     = 'Micron Technology Inc'
+    device     = '2450 NVMe SSD [HendrixV] (DRAM-less)'
+    class      = mass storage
+    subclass   = NVM
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- USB Ports
+xhci0@pci0:0:13:0:	class=0x0c0330 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a13 subvendor=0x17aa subdevice=0x22d4
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Thunderbolt 4 USB Controller'
+    class      = serial bus
+    subclass   = USB
+none3@pci0:0:13:2:	class=0x0c0340 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a1b subvendor=0x17aa subdevice=0x22d4
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Thunderbolt 4 NHI'
+    class      = serial bus
+    subclass   = USB
+none4@pci0:0:13:3:	class=0x0c0340 rev=0x01 hdr=0x00 vendor=0x8086 device=0x9a1d subvendor=0x17aa subdevice=0x22d4
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP Thunderbolt 4 NHI'
+    class      = serial bus
+    subclass   = USB
+xhci1@pci0:0:20:0:	class=0x0c0330 rev=0x20 hdr=0x00 vendor=0x8086 device=0xa0ed subvendor=0x17aa subdevice=0x22d4
+    vendor     = 'Intel Corporation'
+    device     = 'Tiger Lake-LP USB 3.2 Gen 2x1 xHCI Host Controller'
+    class      = serial bus
+    subclass   = USB
+
+  Category Total Score: 1.0/2.0
+
+--------------------
+
+- Bluetooth
+
+ugen1.3: <AX201 Bluetooth Intel Corp.> at usbus1, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (100mA)
+  bDeviceClass = 0x00e0  <Wireless controller>
+  bDeviceSubClass = 0x0001 
+  iManufacturer = 0x0000  <no string>
+  iProduct = 0x0000  <no string>
+  device = 'AX201 Bluetooth Intel Corp.'
+
+  Category Total Score: 0.0/2.0
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+geom_eli.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+hpen.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+if_ure.ko
+ig4.ko
+iichid.ko
+kernel
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+smbus.ko
+uether.ko
+zfs.ko
+
+====================================


### PR DESCRIPTION
# Summary

Initial testing. Intel AX201 detected and can associate with AP, but does not pass traffic, even after disabling HT / VHT (see comments.md).  Overall a smooth experience, desktop-installer successfully installed wayland and KDE Plasma, which runs smoothly with GPU backing.  Audio works but is very quiet - checked `sysctl hw.snd` and mixer `pcm0`, volume is full. Battery health reported correctly at around 4 hours with current settings.

# System information

Laptop make/model: Lenovo ThinkPad X1 Yoga Gen 6
`uname -a` output: FreeBSD enterprise 15.1-RELEASE FreeBSD 15.1-RELEASE releng/15.1-n283562-96841ea08dcf GENERIC amd64


# Tests Completed

## Installation

- [x] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [x] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [ ] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [x] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [x] I can connect my laptop to the internet by tethering with my mobile phone.

- [x] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [x] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [x] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [x] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)

- [ ] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info
