### PR TITLE
Test results for Huawei Matebook D15

### DIFF
--- a/test_results/BOHB_WAX9/comments.md
+++ b/test_results/BOHB_WAX9/comments.md
@@ -1,0 +1,117 @@
+# Notes 
+This is my first report on trying FreeBSD on my Huawei Matebook D15. I have not used it as a daily driver with any operating system. I won it in 2021, and since then have left it untouched because I have used other computers. I installed different operating systems from time to time, but there were always some difficulties, especially with brightness control and the sound card.   
+
+## Brightness 
+Brightness control works as expected after installing `drm-kmod` (adding the `i915kms` kernel module to `/etc/rc.conf`), `xorg`, and `xfce4`, and adding my standard user account (not root) to the `video` group. I set the brightness with the backlight program. I have tried FreeBSD in the past on this machine and brightness control did not work. Now it works, so this is a positive progress.
+
+## Desktop Environment 
+I use XFCE4. I created .xinitrc in my home directory 
+containing the line `ck-launch-session dbus-launch --exit-with-session startxfce4`. I start it with the command `startxfce4`.
+
+## Networking
+Networking was configured automatically during the installation and works.
+
+## Sound
+Sound does not work. I followed the steps of chapter 9.2 `Setting Up The Sound Card` from the handbook.
+In order to load the `snd_driver` at boot time, I placed
+`snd_driver_load` into /boot/loader.conf.
+
+I then executed dmesg | grep pcm: 
+pcm0: <Intel Kaby Lake (HDMI/DP 8ch)> at nid 3 on hdaa0
+pcm0: <Intel Kaby Lake (HDMI/DP 8ch)> at nid 3 on hdaa0
+pcm0: <Intel Kaby Lake (HDMI/DP 8ch)> at nid 3 on hdaa0
+pcm0: <Intel Kaby Lake (HDMI/DP 8ch)> at nid 3 on hdaa0
+
+I then executed cat /dev/sndstat:
+Installed devices:
+pcm0: <Intel Kaby Lake (HDMI/DP 8ch)> (play) default
+No devices installed from userspace.
+
+If I execute beep, this process hangs for some seconds and then terminates, but no noise is produced. 
+
+The output of mixer: 
+pcm0:mixer: <Intel Kaby Lake (HDMI/DP 8ch)> on hdaa0 (play) (default)
+    vol       = 1.00:1.00     pbk
+    pcm       = 1.00:1.00     pbk
+
+I then executed ls -all /dev/dsp:
+crw-rw-rw-  1 root wheel 0x42 Sep 11 10:43 /dev/dsp
+
+I then executed fstat | grep dsp. It produced no output.
+
+Then I started pacmd. I entered the following commands inside pacmd:
+
+list-cards: 
+0 card(s) available.
+
+list-sinks:
+1 sink(s) available.
+  * index: 0
+	name: <oss_output.dsp0>
+	driver: <module-oss.c>
+	flags: HARDWARE HW_VOLUME_CTRL LATENCY 
+	state: SUSPENDED
+	suspend cause: IDLE
+	priority: 0
+	volume: front-left: 65536 / 100%,   front-right: 65536 / 100%
+	        balance 0.00
+	base volume: 65536 / 100%
+	volume steps: 101
+	muted: no
+	current latency: 0.00 ms
+	max request: 16 KiB
+	max rewind: 0 KiB
+	monitor source: 0
+	sample spec: s16le 2ch 44100Hz
+	channel map: front-left,front-right
+	             Stereo
+	used by: 0
+	linked by: 0
+	fixed latency: 92.88 ms
+	module: 6
+	properties:
+		device.string = "/dev/dsp0"
+		device.api = "oss"
+		device.description = "0 - Intel Kaby Lake (HDMI/DP 8ch)"
+		device.access_mode = "mmap"
+		device.buffering.buffer_size = "16384"
+		device.buffering.fragment_size = "4096"
+		device.icon_name = "audio-card"
+
+list-sources:
+1 source(s) available.
+  * index: 0
+	name: <oss_output.dsp0.monitor>
+	driver: <module-oss.c>
+	flags: DECIBEL_VOLUME LATENCY 
+	state: SUSPENDED
+	suspend cause: IDLE
+	priority: 1000
+	volume: front-left: 65536 / 100% / 0.00 dB,   front-right: 65536 / 100% / 0.00 dB
+	        balance 0.00
+	base volume: 65536 / 100% / 0.00 dB
+	volume steps: 65537
+	muted: no
+	current latency: 0.00 ms
+	max rewind: 0 KiB
+	sample spec: s16le 2ch 44100Hz
+	channel map: front-left,front-right
+	             Stereo
+	used by: 0
+	linked by: 0
+	fixed latency: 92.88 ms
+	monitor_of: 0
+	module: 6
+	properties:
+		device.description = "Monitor of 0 - Intel Kaby Lake (HDMI/DP 8ch)"
+		device.class = "monitor"
+		device.icon_name = "audio-input-microphone"
+
+
+
+## Miscellaneous 
+I have not tested the microphone and webcam. The keyboard has no backlight. 
+In general, I have little experience in using this laptop with any OS. 
+
+## Contact
+Feel free to reach out if you have tried running FreeBSD on a Huawei Matebook D15 and ran into issues. We can compare configuration files and try to troubleshoot together. If you need further information (output from programs etc.), please contact me.  

--- a/test_results/BOHB_WAX9/probe_2026-09-11_10-11-33.txt
+++ b/test_results/BOHB_WAX9/probe_2026-09-11_10-11-33.txt
@@ -1,0 +1,129 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 15.1-RELEASE releng/15.1-n283562-96841ea08dcf GENERIC
+Hardware: BOHB_WAX9
+CPU: Intel(R) Core(TM) i3-10110U CPU @ 2.10GHz
+------------------------------------
+
+- Graphics
+vgapci0@pci0:0:2:0:	class=0x030000 rev=0x02 hdr=0x00 vendor=0x8086 device=0x9b41 subvendor=0x152d subdevice=0x125d
+    vendor     = 'Intel Corporation'
+    device     = 'CometLake-U GT2 [UHD Graphics]'
+    class      = display
+    subclass   = VGA
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Networking
+iwlwifi0@pci0:0:20:3:	class=0x028000 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02f0 subvendor=0x8086 subdevice=0x2034
+    vendor     = 'Intel Corporation'
+    device     = '400 Series Chipset Family On-Package CNVi WiFi'
+    class      = network
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Audio
+hdac0@pci0:0:31:3:	class=0x040100 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02c8 subvendor=0x152d subdevice=0x125d
+    vendor     = 'Intel Corporation'
+    device     = '400 Series Chipset Family On-Package HD Audio'
+    class      = multimedia
+    subclass   = audio
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Storage
+ahci0@pci0:0:23:0:	class=0x010601 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02d3 subvendor=0x152d subdevice=0x125d
+    vendor     = 'Intel Corporation'
+    device     = '400 Series Chipset Family On-Package SATA Controller (AHCI)'
+    class      = mass storage
+    subclass   = SATA
+nvme0@pci0:1:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa809 subvendor=0x144d subdevice=0xa801
+    vendor     = 'Samsung Electronics Co Ltd'
+    device     = 'NVMe SSD Controller 980 (DRAM-less)'
+    class      = mass storage
+    subclass   = NVM
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- USB Ports
+xhci0@pci0:0:20:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x8086 device=0x02ed subvendor=0x152d subdevice=0x125d
+    vendor     = 'Intel Corporation'
+    device     = '400 Series Chipset Family On-Package USB 3.2 Gen 2x1 (10 Gbs) xHCI Host Controller'
+    class      = serial bus
+    subclass   = USB
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Bluetooth
+
+ugen0.4: <Bluetooth 9460/9560 Jefferson Peak (JfP) Intel Corp.> at usbus0, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (100mA)
+  bDeviceClass = 0x00e0  <Wireless controller>
+  bDeviceSubClass = 0x0001 
+  iManufacturer = 0x0000  <no string>
+  iProduct = 0x0000  <no string>
+  device = 'Bluetooth 9460/9560 Jefferson Peak (JfP) Intel Corp.'
+
+  Category Total Score: 0.0/2.0
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_wmi.ko
+dmabuf.ko
+drm.ko
+hconf.ko
+hcons.ko
+hidmap.ko
+hms.ko
+hmt.ko
+hsctrl.ko
+i915kms.ko
+ichsmb.ko
+if_iwlwifi.ko
+if_iwx.ko
+ig4.ko
+iic.ko
+iichid.ko
+kernel
+lindebugfs.ko
+linuxkpi_video.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_hci.ko
+ng_ubt.ko
+nlsysevent.ko
+pchtherm.ko
+smbus.ko
+snd_als4000.ko
+snd_atiixp.ko
+snd_cs4281.ko
+snd_driver.ko
+snd_envy24.ko
+snd_envy24ht.ko
+snd_fm801.ko
+snd_hdsp.ko
+snd_hdspe.ko
+snd_maestro3.ko
+snd_neomagic.ko
+snd_solo.ko
+snd_spicds.ko
+snd_t4dwave.ko
+snd_uaudio.ko
+snd_via82c686.ko
+snd_vibes.ko
+ttm.ko
+zfs.ko
+
+====================================


### PR DESCRIPTION
# Summary
1. Wireless networking was configured during installation and works. I did not test wired networking.
2. Brightness can be set with the backlight utility. It did not work with earlier releases of FreeBSD.
3. The sound does not work. I placed the outputs of different programs in the **comments.md**. If you are a developer or someone who uses this laptop with FreeBSD too, it may be helpful.  For that reason I did not mark issue 19.
4. **Suspend** works. I needed to install **lightdm** and **lightdm-gtk-greeter**. I added **lightdm_enable="YES"** to my **/etc/rc.conf** and after rebooting, every option is availabe in the log out menu. 
5. The option **Hibernate** does not work. It powers off this computer. 
6. When using the keys F1-F12, it is important that the small LED on the Fn key is turned on, because otherwise my system freezes. I did not know that, so I did Fn+F3 to open the Application Finder, but shortly afterwards I could not use the panel anymore. I had to restart xfce4 and xorg.  

It would be nice to get the sound working on this laptop. 

Feel free to reach out if you have tried running FreeBSD on a Huawei Matebook D15 and ran into issues. We can compare configuration files. If you need further information (output from programs etc.), please contact me. 

Issue 7: When the laptop lid is closed, I chose the option **Suspend** in the Power Manager and it works.

Issue 15: When I connect headphones via USB, unpleasant high-pitched frequencies come out of them. (They work with other operating systems.) I haven't looked into it any further, as I don't need them. This happens with my Lenovo T530 too. See my other pull request #102. They appear in the output of dmesg: ugen0.5: <Logi USB Headset Logi USB Headset> at usbus0. 

Issues I did not test: 3, 6, 9, 11-14, 18, 21

# System information

Laptop make/model: Huawei Matebook D15
`uname -a` output: FreeBSD MB 15.1-RELEASE FreeBSD 15.1-RELEASE releng/15.1-n283562-96841ea08dcf GENERIC amd64

# Tests Completed

## Installation

- [x] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)

## Wireless

- [ ] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [x] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [x] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [ ] I can connect my laptop to the internet by tethering with my mobile phone.

- [ ] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [ ] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)

- [ ] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [ ] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [ ] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.

## Power

- [ ] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)

- [ ] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)

- [ ] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)

## User Experience

- [ ] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [ ] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [ ] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)

- [x] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [ ] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)

- [ ] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)

# Additional Info
