### PR TITLE
Test: Lenovo ThinkBook 16 G7 ARP

### DIFF
--- a/test_results/Lenovo_ThinkBook_16_G7_ARP/comments.md
+++ b/test_results/Lenovo_ThinkBook_16_G7_ARP/comments.md
@@ -2,7 +2,7 @@ FreeBSD 16.0-CURRENT as of 12/09/2026 (d m y)
 
 Ethernet works wonderfully, but Realtek 8852CE wifi causes system to hang
 when attempting to setup wifi device. System even may hang during boot at
-linker 32 bit something after that (although, i haven't installet 32 bit 
+linker 32 bit something after that (although, i haven't installet 32 bit
 compatibility libraries). fsck from LiveCD helps.
 
 Radeon 660M works without issues.
@@ -11,27 +11,43 @@ About battery. After enabling powerd (w roughly default options) and
 setting cstate to Cmax (sysctl hw.acpi.cpu.cx_lowest=Cmax) at least 4/5 of
 usual lifetime before recharge can be expected.
 
-Builtin audio dynamic work is not consistent between reboots, usually
+~~Builtin audio dynamic work is not consistent between reboots, usually
 aren't workin' at all. Following may or may not help (Microphone stops working
-with this, you still need to manually switch sink after plugging headphones)
+with this, you still need to manually switch sink after plugging headphones)~~
 
-/boot/device.hints:
+
+~~/boot/device.hints:
     hint.hdaa.1.nid20.config="as=1 seq=0 device=Speaker"
-    hint.hdaa.1.nid18.config="as=2 seq=0 device=Mic"
+    hint.hdaa.1.nid18.config="as=2 seq=0 device=Mic"~~
 
-Volume is really low, this may help a bit:
-/etc/sysctl.conf:
-    hw.snd.vpc_0db=5
-    $ mixer vol=100
+~~Volume is really low, this may help a bit:
+    /etc/sysctl.conf:
+        hw.snd.vpc_0db=5
+    $ mixer vol=100~~
+
+UPD:Whatever, do this and it will be fine:
+```
+   $ mixer vol=1.0 \
+   $ mixer pcm=1.0 \
+/boot/device.hints:
+    hint.hdaa.1.nid20.config="as=1 seq=0 device=Speakers"
+    hint.hdaa.1.nid33.config="as=1 seq=15 device=Headphones"
+
+/etc/sysctl.conf
+    hw.snd.vpc_0db=1
+```
 
 Hwprobe shows that bluetooth is working but I haven't f****d around with
 it, so dunno.
 
-Backlight and some FN keys are working after loading acpi_ibm module,
-though can't tell if every key is working.
+Most FN keys are working after loading acpi_ibm module,
+except backlight keys.
 
 Even though laptop doesn't support S3 sleep, suspend_to_idle is kinda
-workin' ok after a little configuration.
+workin' ok after a little configuration:
+```
+/etc/sysctl.conf:
+    hw.acpi.lid_switch_state="suspend_to_idle"
+    hw.acpi.power_button_state="suspend_to_idle"
 
-Suspect could be used as main OS on this laptop, if you could not
-configure audio it will be sad though.
+```

--- a/test_results/Lenovo_ThinkBook_16_G7_ARP/comments.md
+++ b/test_results/Lenovo_ThinkBook_16_G7_ARP/comments.md
@@ -1,0 +1,37 @@
+FreeBSD 16.0-CURRENT as of 12/09/2026 (d m y)
+
+    Ethernet works wonderfully, but Realtek 8852CE wifi causes system to hang
+when attempting to setup wifi device. System even may hang during boot at
+linker 32 bit something after that (although, i haven't installet 32 bit 
+compatibility libraries). fsck from LiveCD helps.
+
+    Radeon 660M works without issues.
+
+    About battery. After enabling powerd (w roughly default options) and
+setting cstate to Cmax (sysctl hw.acpi.cpu.cx_lowest=Cmax) at least 4/5 of
+usual lifetime before recharge can be expected.
+
+    Builtin audio dynamic work is not consistent between reboots, usually
+aren't workin' at all. Following may or may not help (Microphone stops working
+with this, you still need to manually switch sink after plugging headphones)
+
+    /boot/device.hints:
+        hint.hdaa.1.nid20.config="as=1 seq=0 device=Speaker"
+        hint.hdaa.1.nid18.config="as=2 seq=0 device=Mic"
+
+    Volume is really low, this may help a bit:
+    /etc/sysctl.conf:
+        hw.snd.vpc_0db=5
+    $ mixer vol=100
+
+    Hwprobe shows that bluetooth is working but I haven't f****d around with
+it, so dunno.
+
+    Backlight and some FN keys are working after loading acpi_ibm module,
+though can't tell if every key is working.
+
+    Even though laptop doesn't support S3 sleep, suspend_to_idle is kinda
+workin' ok after a little configuration.
+
+    Suspect could be used as main OS on this laptop, if you could not
+configure audio it will be sad though.

--- a/test_results/Lenovo_ThinkBook_16_G7_ARP/comments.md
+++ b/test_results/Lenovo_ThinkBook_16_G7_ARP/comments.md
@@ -1,37 +1,37 @@
 FreeBSD 16.0-CURRENT as of 12/09/2026 (d m y)
 
-    Ethernet works wonderfully, but Realtek 8852CE wifi causes system to hang
+Ethernet works wonderfully, but Realtek 8852CE wifi causes system to hang
 when attempting to setup wifi device. System even may hang during boot at
 linker 32 bit something after that (although, i haven't installet 32 bit 
 compatibility libraries). fsck from LiveCD helps.
 
-    Radeon 660M works without issues.
+Radeon 660M works without issues.
 
-    About battery. After enabling powerd (w roughly default options) and
+About battery. After enabling powerd (w roughly default options) and
 setting cstate to Cmax (sysctl hw.acpi.cpu.cx_lowest=Cmax) at least 4/5 of
 usual lifetime before recharge can be expected.
 
-    Builtin audio dynamic work is not consistent between reboots, usually
+Builtin audio dynamic work is not consistent between reboots, usually
 aren't workin' at all. Following may or may not help (Microphone stops working
 with this, you still need to manually switch sink after plugging headphones)
 
-    /boot/device.hints:
-        hint.hdaa.1.nid20.config="as=1 seq=0 device=Speaker"
-        hint.hdaa.1.nid18.config="as=2 seq=0 device=Mic"
+/boot/device.hints:
+    hint.hdaa.1.nid20.config="as=1 seq=0 device=Speaker"
+    hint.hdaa.1.nid18.config="as=2 seq=0 device=Mic"
 
-    Volume is really low, this may help a bit:
-    /etc/sysctl.conf:
-        hw.snd.vpc_0db=5
+Volume is really low, this may help a bit:
+/etc/sysctl.conf:
+    hw.snd.vpc_0db=5
     $ mixer vol=100
 
-    Hwprobe shows that bluetooth is working but I haven't f****d around with
+Hwprobe shows that bluetooth is working but I haven't f****d around with
 it, so dunno.
 
-    Backlight and some FN keys are working after loading acpi_ibm module,
+Backlight and some FN keys are working after loading acpi_ibm module,
 though can't tell if every key is working.
 
-    Even though laptop doesn't support S3 sleep, suspend_to_idle is kinda
+Even though laptop doesn't support S3 sleep, suspend_to_idle is kinda
 workin' ok after a little configuration.
 
-    Suspect could be used as main OS on this laptop, if you could not
+Suspect could be used as main OS on this laptop, if you could not
 configure audio it will be sad though.

--- a/test_results/Lenovo_ThinkBook_16_G7_ARP/probe_2026-09-12_00-20-23.txt
+++ b/test_results/Lenovo_ThinkBook_16_G7_ARP/probe_2026-09-12_00-20-23.txt
@@ -1,0 +1,185 @@
+=== FreeBSD Hardware Status Info ===
+
+Running: FreeBSD 16.0-CURRENT main-n289005-fc33bbb02450 GENERIC
+Hardware: 21MW
+CPU: AMD Ryzen 5 7535HS with Radeon Graphics        
+------------------------------------
+
+- Graphics
+vgapci0@pci0:117:0:0:	class=0x030000 rev=0x0b hdr=0x00 vendor=0x1002 device=0x1681 subvendor=0x17aa subdevice=0x3821
+    vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+    device     = 'Rembrandt [Radeon 680M]'
+    class      = display
+    subclass   = VGA
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Networking
+re0@pci0:1:0:0:	class=0x020000 rev=0x15 hdr=0x00 vendor=0x10ec device=0x8168 subvendor=0x17aa subdevice=0x3983
+    vendor     = 'Realtek Semiconductor Co., Ltd.'
+    device     = 'RTL8111/8168/8211/8411 PCI Express Gigabit Ethernet Controller'
+    class      = network
+    subclass   = ethernet
+rtw890@pci0:2:0:0:	class=0x028000 rev=0x01 hdr=0x00 vendor=0x10ec device=0xc852 subvendor=0x17aa subdevice=0x5852
+    vendor     = 'Realtek Semiconductor Co., Ltd.'
+    device     = 'RTL8852CE PCIe 802.11ax Wireless Network Controller'
+    class      = network
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- Audio
+hdac0@pci0:117:0:1:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1002 device=0x1640 subvendor=0x17aa subdevice=0x383c
+    vendor     = 'Advanced Micro Devices, Inc. [AMD/ATI]'
+    device     = 'Radeon High Definition Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+none2@pci0:117:0:5:	class=0x048000 rev=0x60 hdr=0x00 vendor=0x1022 device=0x15e2 subvendor=0x17aa subdevice=0x38a2
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Audio Coprocessor'
+    class      = multimedia
+hdac1@pci0:117:0:6:	class=0x040300 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15e3 subvendor=0x17aa subdevice=0x389b
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Ryzen HD Audio Controller'
+    class      = multimedia
+    subclass   = HDA
+
+  Category Total Score: 1.3/2.0
+
+--------------------
+
+- Storage
+nvme0@pci0:4:0:0:	class=0x010802 rev=0x00 hdr=0x00 vendor=0x144d device=0xa80d subvendor=0x144d subdevice=0xa801
+    vendor     = 'Samsung Electronics Co Ltd'
+    device     = 'NVMe SSD Controller PM9C1a (DRAM-less)'
+    class      = mass storage
+    subclass   = NVM
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+- USB Ports
+xhci0@pci0:117:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x161d subvendor=0x17aa subdevice=0x3806
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Rembrandt USB4 XHCI controller'
+    class      = serial bus
+    subclass   = USB
+xhci1@pci0:117:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x161e subvendor=0x17aa subdevice=0x3808
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Rembrandt USB4 XHCI controller'
+    class      = serial bus
+    subclass   = USB
+xhci2@pci0:118:0:0:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x161f subvendor=0x17aa subdevice=0x3041
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Rembrandt USB4 XHCI controller'
+    class      = serial bus
+    subclass   = USB
+xhci3@pci0:118:0:3:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15d6 subvendor=0x1022 subdevice=0x15d6
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Rembrandt USB4 XHCI controller'
+    class      = serial bus
+    subclass   = USB
+xhci4@pci0:118:0:4:	class=0x0c0330 rev=0x00 hdr=0x00 vendor=0x1022 device=0x15d7 subvendor=0x1022 subdevice=0x15d7
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Rembrandt USB4 XHCI controller'
+    class      = serial bus
+    subclass   = USB
+none3@pci0:118:0:6:	class=0x0c0340 rev=0x00 hdr=0x00 vendor=0x1022 device=0x162f subvendor=0x1022 subdevice=0x162f
+    vendor     = 'Advanced Micro Devices, Inc. [AMD]'
+    device     = 'Rembrandt USB4/Thunderbolt NHI controller'
+    class      = serial bus
+    subclass   = USB
+
+  Category Total Score: 1.7/2.0
+
+--------------------
+
+- Bluetooth
+
+ugen1.2: <Bluetooth Radio Realtek Semiconductor Corp.> at usbus1, cfg=0 md=HOST spd=FULL (12Mbps) pwr=ON (500mA)
+  bDeviceClass = 0x00e0  <Wireless controller>
+  bDeviceSubClass = 0x0001 
+  iManufacturer = 0x0001  <Realtek>
+  iProduct = 0x0002  <Bluetooth Radio>
+  device = 'Bluetooth Radio Realtek Semiconductor Corp.'
+
+  Category Total Score: 2.0/2.0
+
+--------------------
+
+=== FreeBSD Detailed Status Info ==
+
+Currently loaded kernel modules:
+acpi_ibm.ko
+acpi_wmi.ko
+amdgpio.ko
+amdgpu.ko
+amdgpu_yellow_carp_ce_bin.ko
+amdgpu_yellow_carp_dmcub_bin.ko
+amdgpu_yellow_carp_me_bin.ko
+amdgpu_yellow_carp_mec2_bin.ko
+amdgpu_yellow_carp_mec_bin.ko
+amdgpu_yellow_carp_pfp_bin.ko
+amdgpu_yellow_carp_rlc_bin.ko
+amdgpu_yellow_carp_sdma_bin.ko
+amdgpu_yellow_carp_ta_bin.ko
+amdgpu_yellow_carp_toc_bin.ko
+amdgpu_yellow_carp_vcn_bin.ko
+amdpm.ko
+amdsmb.ko
+amdsmn.ko
+amdsmu.ko
+amdtemp.ko
+cuse.ko
+dmabuf.ko
+drm.ko
+fusefs.ko
+gpiobus.ko
+hconf.ko
+hidmap.ko
+hms.ko
+hmt.ko
+if_rtw89.ko
+ig4.ko
+iic.ko
+iichid.ko
+intpm.ko
+kernel
+lindebugfs.ko
+linuxkpi_video.ko
+mac_ntpd.ko
+netgraph.ko
+ng_bluetooth.ko
+ng_btsocket.ko
+ng_hci.ko
+ng_l2cap.ko
+ng_socket.ko
+ng_ubt.ko
+nlsysevent.ko
+smbus.ko
+snd_als4000.ko
+snd_atiixp.ko
+snd_cs4281.ko
+snd_driver.ko
+snd_envy24.ko
+snd_envy24ht.ko
+snd_fm801.ko
+snd_hdsp.ko
+snd_hdspe.ko
+snd_maestro3.ko
+snd_neomagic.ko
+snd_solo.ko
+snd_spicds.ko
+snd_t4dwave.ko
+snd_uaudio.ko
+snd_via82c686.ko
+snd_vibes.ko
+ttm.ko
+uvideo.ko
+video.ko
+
+====================================


### PR DESCRIPTION
# Summary

Used this laptop with FreeBSD for a couple of days. Most things works good.

WIFI (Realtek 8852ce): Trying to connect to wireless network hangs the system. When rebooting hangs at another place (something about linker 32 bit libs stuff, may be due to not configured 32 bit compatibility (rtw89(4) BUGS). Can recall it working about half a year ago with 32 bit compatibility). Though, fsck fixes it without any crap. 

~~AUDIO (Realtek ACL 257): Could not properly configure it to work, even when it works volume level is inconsistent.~~ Solved in comments.md

# System information

Laptop make/model:
FreeBSD daemon 16.0-CURRENT FreeBSD 16.0-CURRENT main-n289005-fc33bbb02450 GENERIC amd64

# Tests Completed

## Installation

- [N] I can install FreeBSD easily as a new user and jump into a graphical desktop environment on the next boot.
    (FreeBSDFoundation/proj-laptop Issue 25)
Had to configure everything myself.

## Wireless

- [~Y] The laptop has Wi-Fi 5 support (802.11ac)
    (FreeBSDFoundation/proj-laptop Issue 33)

- [~Y] The laptop has Wi-Fi 6/6E support (802.11ax), with observed speeds of 1Gbps+.
    (FreeBSDFoundation/proj-laptop Issue 34)

- [Y] The laptop automatically connects to known Wi-Fi networks without requiring me to manually reconnect each time.
    (FreeBSDFoundation/proj-laptop Issue 4)

- [Y] I can connect my laptop to the internet by tethering with my mobile phone.

- [N] There is a built-in tool to identify available WiFi networks, choose one to connect to, and provide a passphrase.
    (FreeBSDFoundation/proj-laptop Issue 3)

## Audio/Video

- [~Y] Sound seamlessly switches to headphones when plugged in, and back to speakers when plugged out.
    (FreeBSDFoundation/proj-laptop Issue 15)
Some configuration needed.

- [Y] Graphical applications (such as games and media content creation tools) run smoothly on the laptop at the screen refresh rate or higher.
    (FreeBSDFoundation/proj-laptop Issue 11)
    (FreeBSDFoundation/proj-laptop Issue 13)

- [Y] I can share my screen on all popular browsers and other applications that request the webcam.
    (FreeBSDFoundation/proj-laptop Issue 14)

- [Y] I can stay connected in a virtual meeting for an hour or longer on all popular video conferencing software with no disruptions.
## Power

- [~Y] The laptop lasts through an 8-hour workday on a single charge
    (FreeBSDFoundation/proj-laptop Issue 6)
Could barely use it up to 6 hours on single charge, though not much lost on FreeBSD
- [~Y] I can close the lid to enter sleep mode, then open the lid hours later to resume working.
    (FreeBSDFoundation/proj-laptop Issue 7)
S3 isn't supported by laptop, though suspend_to_idle works fine after switching to it.
- [?] The laptop can enter and resume from hibernation mode with no change to its operating state.
    (FreeBSDFoundation/proj-laptop Issue 29)
Untested, is hibernation supported yet?

## User Experience

- [Y] I can change the keyboard backlight and display backlight to view at a comfortable brightness.

- [Y] I can use multi-finger touchpad gestures in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 18)

- [~Y] All of the laptop's specialty keyboard buttons (e.g. brightness, volume, etc.) work correctly and can be customized in my desktop environment.
    (FreeBSDFoundation/proj-laptop Issue 19)
All special keys except for brightness work good. (messed up about that in comments.md)
- [Y] I can connect to an external monitor or projector using HDMI while using my desktop environment's display settings manager to configure it.
    (FreeBSDFoundation/proj-laptop Issue 27)

## Virtualization

- [?] Suspending the laptop while a VM is running does not affect the VM's state upon resume.
    (FreeBSDFoundation/proj-laptop Issue 9)
Untested
- [?] I can run Windows VMs on the laptop.
    (FreeBSDFoundation/proj-laptop Issue 21)
Untested
# Additional Info
Forgive me screwing with this pull request, i am unexperienced.